### PR TITLE
This commit implements the following:

### DIFF
--- a/marlin-succinct/circuits/src/compiled.rs
+++ b/marlin-succinct/circuits/src/compiled.rs
@@ -36,7 +36,7 @@ pub struct Compiled<E: PairingEngine>
 impl<E: PairingEngine> Compiled<E>
 {
     // this function compiles the constraints
-    //  urs: univarsal reference string
+    //  urs: universal reference string
     //  h_group: evaluation domain for degere h (constrtraint matrix linear size)
     //  k_group: evaluation domain for degere k (constrtraint matrix number of non-zero elements)
     //  b_group: evaluation domain for degere b (h_group*6-6)
@@ -87,7 +87,7 @@ impl<E: PairingEngine> Compiled<E>
         // commit to the index polynomials
         Ok(Compiled::<E>
         {
-            constraints: constraints,
+            constraints,
             row_comm: urs.commit(&row, k_group.size())?,
             col_comm: urs.commit(&col, k_group.size())?,
             val_comm: urs.commit(&val, k_group.size())?,

--- a/marlin-succinct/circuits/src/index.rs
+++ b/marlin-succinct/circuits/src/index.rs
@@ -88,7 +88,21 @@ impl<E: PairingEngine> Index<E>
                     .map_or(Err(ProofError::RuntimeEnv), |s| Ok(s))?;
      
                 // compute public setup
-                let urs = URS::<E>::create(max_degree, rng);
+                let urs = URS::<E>::create
+                (
+                    max_degree,
+                    vec!
+                    [
+                        h_group.size(),
+                        h_group.size() - x_group.size(),
+                        h_group.size()*2-2,
+                        h_group.size()-1,
+                        k_group.size()*6-6,
+                        k_group.size()-1,
+                        k_group.size()
+                    ],
+                    rng
+                );
 
                 // compile the constraints
                 Ok(Index::<E>

--- a/marlin-succinct/commitment/src/commitment.rs
+++ b/marlin-succinct/commitment/src/commitment.rs
@@ -177,6 +177,7 @@ impl<E: PairingEngine> URS<E>
 
             for (z, y) in prf[0].2.iter().zip(pcomm.iter_mut())
             {
+                if !self.hn.contains_key(&(d-z.2)) {return false}
                 table.push
                 ((
                     Self::multiexp(&y).prepare(),

--- a/marlin-succinct/commitment/src/commitment.rs
+++ b/marlin-succinct/commitment/src/commitment.rs
@@ -180,12 +180,12 @@ impl<E: PairingEngine> URS<E>
                 table.push
                 ((
                     Self::multiexp(&y).prepare(),
-                    (-self.hn[d-z.2]).prepare()
+                    (-self.hn[&(d-z.2)]).prepare()
                 ));
             }
         }
         table.push((Self::multiexp(&open).prepare(), self.hx.prepare()));
-        table.push((Self::multiexp(&openy).prepare(), self.hn[0].prepare()));
+        table.push((Self::multiexp(&openy).prepare(), E::G2Affine::prime_subgroup_generator().prepare()));
     
         let x: Vec<(&<E::G1Affine as PairingCurve>::Prepared, &<E::G2Affine as PairingCurve>::Prepared)> = table.iter().map(|x| (&x.0, &x.1)).collect();
         E::final_exponentiation(&E::miller_loop(&x)).unwrap() == E::Fqk::one()

--- a/marlin-succinct/commitment/src/urs.rs
+++ b/marlin-succinct/commitment/src/urs.rs
@@ -4,7 +4,7 @@ This source file implements the Marlin universal reference string primitive
 
 *****************************************************************************************************************/
 
-use algebra::{VariableBaseMSM, AffineCurve, ProjectiveCurve, Field, PrimeField, PairingEngine, BigInteger, PairingCurve, UniformRand};
+use algebra::{VariableBaseMSM, FixedBaseMSM, AffineCurve, ProjectiveCurve, Field, PrimeField, PairingEngine, PairingCurve, UniformRand};
 use std::collections::HashMap;
 use rand_core::RngCore;
 
@@ -39,10 +39,22 @@ impl<E: PairingEngine> URS<E>
     ) -> Self
     {
         let mut x = E::Fr::rand(rng);
-        let mut g = Wnaf::new();
-        let mut g = g.base(E::G1Projective::prime_subgroup_generator(), depth);
+        let size_in_bits = E::Fr::size_in_bits();
+        let window_size = FixedBaseMSM::get_mul_window_size(depth+1);
+
         let mut cur = E::Fr::one();
-        let mut gp: Vec<E::G1Projective> = (0..depth).map(|_| {let ret = g.scalar(cur.into_repr()); cur *= &x; ret}).collect();
+        let mut gp = FixedBaseMSM::multi_scalar_mul::<E::G1Projective>
+        (
+            size_in_bits,
+            window_size,
+            &FixedBaseMSM::get_window_table
+            (
+                size_in_bits,
+                window_size,
+                E::G1Projective::prime_subgroup_generator()
+            ),
+            &(0..depth).map(|_| {let s = cur; cur *= &x; s}).collect::<Vec<E::Fr>>(),
+        );
         ProjectiveCurve::batch_normalization(&mut gp);
 
         let mut gx = E::G1Projective::prime_subgroup_generator();
@@ -50,10 +62,20 @@ impl<E: PairingEngine> URS<E>
         let mut hx = E::G2Projective::prime_subgroup_generator();
         hx.mul_assign(x);
 
+        let window_size = FixedBaseMSM::get_mul_window_size(degrees.len()+1);
         x = x.inverse().unwrap();
-        let mut h = Wnaf::new();
-        let mut h = h.base(E::G2Projective::prime_subgroup_generator(), depth);
-        let mut hn: Vec<E::G2Projective> = degrees.iter().map(|i| {h.scalar(x.pow([(depth - *i) as u64]).into_repr())}).collect();
+        let mut hn = FixedBaseMSM::multi_scalar_mul::<E::G2Projective>
+        (
+            size_in_bits,
+            window_size,
+            &FixedBaseMSM::get_window_table
+            (
+                size_in_bits,
+                window_size,
+                E::G2Projective::prime_subgroup_generator()
+            ),
+            &degrees.iter().map(|i| x.pow([(depth - *i) as u64])).collect::<Vec<E::Fr>>(),
+        );
         ProjectiveCurve::batch_normalization(&mut hn);
         let mut hnh: HashMap<usize, E::G2Affine> = HashMap::new();
         for (i, p) in degrees.iter().zip(hn.iter()) {hnh.insert(depth - *i, p.into_affine());}
@@ -134,186 +156,5 @@ impl<E: PairingEngine> URS<E>
                 ).into_affine().prepare(), &(-self.hx).prepare()
             ),
         ])).unwrap() == E::Fqk::one()
-    }
-}
-
-// The code below for w-ary non-adjacent form (wNAF) method (for fast
-// elliptic curve point multiplication) has been adapted from Rust::Pairing trait
-
-/// Replaces the contents of `table` with a w-NAF window table for the given window size.
-pub(crate) fn wnaf_table<G: ProjectiveCurve>(table: &mut Vec<G>, mut base: G, window: usize) {
-    table.truncate(0);
-    table.reserve(1 << (window - 1));
-
-    let mut dbl = base;
-    dbl = dbl.double();
-
-    for _ in 0..(1 << (window - 1)) {
-        table.push(base);
-        base.add_assign(&dbl);
-    }
-}
-
-/// Replaces the contents of `wnaf` with the w-NAF representation of a scalar.
-pub(crate) fn wnaf_form<S: BigInteger>(wnaf: &mut Vec<i64>, mut c: S, window: usize) {
-    wnaf.truncate(0);
-
-    while !c.is_zero() {
-        let mut u;
-        if c.is_odd() {
-            u = (c.as_ref()[0] % (1 << (window + 1))) as i64;
-
-            if u > (1 << window) {
-                u -= 1 << (window + 1);
-            }
-
-            if u > 0 {
-                c.sub_noborrow(&S::from(u as u64));
-            } else {
-                c.add_nocarry(&S::from((-u) as u64));
-            }
-        } else {
-            u = 0;
-        }
-
-        wnaf.push(u);
-
-        c.div2();
-    }
-}
-
-/// Performs w-NAF exponentiation with the provided window table and w-NAF form scalar.
-///
-/// This function must be provided a `table` and `wnaf` that were constructed with
-/// the same window size; otherwise, it may panic or produce invalid results.
-pub(crate) fn wnaf_exp<G: ProjectiveCurve>(table: &[G], wnaf: &[i64]) -> G {
-    let mut result = G::zero();
-
-    let mut found_one = false;
-
-    for n in wnaf.iter().rev() {
-        if found_one {
-            result = result.double();
-        }
-
-        if *n != 0 {
-            found_one = true;
-
-            if *n > 0 {
-                result.add_assign(&table[(n / 2) as usize]);
-            } else {
-                result.sub_assign(&table[((-n) / 2) as usize]);
-            }
-        }
-    }
-
-    result
-}
-
-/// A "w-ary non-adjacent form" exponentiation context.
-#[derive(Debug)]
-pub struct Wnaf<W, B, S> {
-    base: B,
-    scalar: S,
-    window_size: W,
-}
-
-impl<G: ProjectiveCurve> Wnaf<(), Vec<G>, Vec<i64>> {
-    /// Construct a new wNAF context without allocating.
-    pub fn new() -> Self {
-        Wnaf {
-            base: vec![],
-            scalar: vec![],
-            window_size: (),
-        }
-    }
-
-    /// Given a base and a number of scalars, compute a window table and return a `Wnaf` object that
-    /// can perform exponentiations with `.scalar(..)`.
-    pub fn base(&mut self, base: G, num_scalars: usize) -> Wnaf<usize, &[G], &mut Vec<i64>> {
-        // Compute the appropriate window size based on the number of scalars.
-        let window_size = G::recommended_wnaf_for_num_scalars(num_scalars);
-
-        // Compute a wNAF table for the provided base and window size.
-        wnaf_table(&mut self.base, base, window_size);
-
-        // Return a Wnaf object that immutably borrows the computed base storage location,
-        // but mutably borrows the scalar storage location.
-        Wnaf {
-            base: &self.base[..],
-            scalar: &mut self.scalar,
-            window_size,
-        }
-    }
-
-    /// Given a scalar, compute its wNAF representation and return a `Wnaf` object that can perform
-    /// exponentiations with `.base(..)`.
-    pub fn scalar(
-        &mut self,
-        scalar: <<G as ProjectiveCurve>::ScalarField as PrimeField>::BigInt,
-    ) -> Wnaf<usize, &mut Vec<G>, &[i64]> {
-        // Compute the appropriate window size for the scalar.
-        let window_size = G::recommended_wnaf_for_scalar(scalar);
-
-        // Compute the wNAF form of the scalar.
-        wnaf_form(&mut self.scalar, scalar, window_size);
-
-        // Return a Wnaf object that mutably borrows the base storage location, but
-        // immutably borrows the computed wNAF form scalar location.
-        Wnaf {
-            base: &mut self.base,
-            scalar: &self.scalar[..],
-            window_size,
-        }
-    }
-}
-
-impl<'a, G: ProjectiveCurve> Wnaf<usize, &'a [G], &'a mut Vec<i64>> {
-    /// Constructs new space for the scalar representation while borrowing
-    /// the computed window table, for sending the window table across threads.
-    pub fn shared(&self) -> Wnaf<usize, &'a [G], Vec<i64>> {
-        Wnaf {
-            base: self.base,
-            scalar: vec![],
-            window_size: self.window_size,
-        }
-    }
-}
-
-impl<'a, G: ProjectiveCurve> Wnaf<usize, &'a mut Vec<G>, &'a [i64]> {
-    /// Constructs new space for the window table while borrowing
-    /// the computed scalar representation, for sending the scalar representation
-    /// across threads.
-    pub fn shared(&self) -> Wnaf<usize, Vec<G>, &'a [i64]> {
-        Wnaf {
-            base: vec![],
-            scalar: self.scalar,
-            window_size: self.window_size,
-        }
-    }
-}
-
-impl<B, S: AsRef<[i64]>> Wnaf<usize, B, S> {
-    /// Performs exponentiation given a base.
-    pub fn base<G: ProjectiveCurve>(&mut self, base: G) -> G
-    where
-        B: AsMut<Vec<G>>,
-    {
-        wnaf_table(self.base.as_mut(), base, self.window_size);
-        wnaf_exp(self.base.as_mut(), self.scalar.as_ref())
-    }
-}
-
-impl<B, S: AsMut<Vec<i64>>> Wnaf<usize, B, S> {
-    /// Performs exponentiation given a scalar.
-    pub fn scalar<G: ProjectiveCurve>(
-        &mut self,
-        scalar: <<G as ProjectiveCurve>::ScalarField as PrimeField>::BigInt,
-    ) -> G
-    where
-        B: AsRef<[G]>,
-    {
-        wnaf_form(self.scalar.as_mut(), scalar, self.window_size);
-        wnaf_exp(self.base.as_ref(), self.scalar.as_mut())
     }
 }

--- a/marlin-succinct/commitment/tests/batch.rs
+++ b/marlin-succinct/commitment/tests/batch.rs
@@ -38,6 +38,7 @@ fn test<E: PairingEngine>()
     let urs = URS::<E>::create
     (
         depth,
+        vec![depth-1, depth-2, depth-3],
         rng
     );
 
@@ -58,21 +59,21 @@ fn test<E: PairingEngine>()
         let mut max: Vec<usize> = Vec::new();
         let mut eval: Vec<E::Fr> = Vec::new();
 
-        let mut plnm = DensePolynomial::<E::Fr>::rand(depth-1, rng);
+        let mut plnm = DensePolynomial::<E::Fr>::rand(depth-2, rng);
 
-        max.push(plnm.coeffs.len());
-        eval.push(plnm.evaluate(elm));
-        plnms.push(plnm);
-
-        plnm = DensePolynomial::<E::Fr>::rand(depth-2, rng);
-        
-        max.push(plnm.coeffs.len());
+        max.push(depth-1);
         eval.push(plnm.evaluate(elm));
         plnms.push(plnm);
 
         plnm = DensePolynomial::<E::Fr>::rand(depth-3, rng);
         
-        max.push(plnm.coeffs.len());
+        max.push(depth-2);
+        eval.push(plnm.evaluate(elm));
+        plnms.push(plnm);
+
+        plnm = DensePolynomial::<E::Fr>::rand(depth-4, rng);
+        
+        max.push(depth-3);
         eval.push(plnm.evaluate(elm));
         plnms.push(plnm);
 

--- a/marlin-succinct/commitment/tests/single.rs
+++ b/marlin-succinct/commitment/tests/single.rs
@@ -35,18 +35,18 @@ fn test<E: PairingEngine>()
     let depth = 500;
 
     // generate sample URS
-    let urs = URS::<E>::create(depth, rng);
+    let urs = URS::<E>::create(depth, vec![300], rng);
 
     // generate sample random vector of polynomials over the base field, commit and evaluate them
     let mut plnms: Vec<(E::Fr, E::Fr, Vec<(E::G1Affine, E::Fr, usize)>, E::G1Affine)> = Vec::new();
     for _ in 0..10
     {
-        let plnm = DensePolynomial::<E::Fr>::rand(depth-1, rng);
+        let plnm = DensePolynomial::<E::Fr>::rand(299, rng);
         let y = E::Fr::rand(rng);
         // Commit/Open and verify the polynomial commitments
-        match (urs.commit(&plnm, plnm.coeffs.len()), urs.open(&plnm, y))
+        match (urs.commit(&plnm, 300), urs.open(&plnm, y))
         {
-            (Ok(comm), Ok(prf)) => {plnms.push((y, E::Fr::one(), vec![(comm, plnm.evaluate(y), plnm.coeffs.len())], prf));}
+            (Ok(comm), Ok(prf)) => {plnms.push((y, E::Fr::one(), vec![(comm, plnm.evaluate(y), 300)], prf));}
             (_,_) => {panic!("This error should not happen")}
         }
     }

--- a/marlin-succinct/commitment/tests/urs.rs
+++ b/marlin-succinct/commitment/tests/urs.rs
@@ -12,8 +12,6 @@ This source file, for now, implements URS unit test suite driver. The following 
 use algebra::{PairingEngine, curves::bls12_381::Bls12_381};
 use commitment::urs::URS;
 use colored::Colorize;
-use std::io;
-use std::io::Write;
 use std::time::{Instant};
 use rand_core::OsRng;
 
@@ -23,13 +21,6 @@ use rand_core::OsRng;
 fn urs_test()
 {
     test::<Bls12_381>();
-}
-
-#[allow(dead_code)]
-fn progress(depth: usize)
-{
-    print!("{:?}\r", depth);
-    io::stdout().flush().unwrap();
 }
 
 fn test<E: PairingEngine>()
@@ -64,7 +55,7 @@ fn test<E: PairingEngine>()
 
         println!("{}", "Verifying the update against its zk-proof".green());
         start = Instant::now();
-        assert_eq!(urs.check(hx, progress, &mut rng), true);
+        assert_eq!(urs.check(hx, &mut rng), true);
         println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());
     }
 }

--- a/marlin-succinct/commitment/tests/urs.rs
+++ b/marlin-succinct/commitment/tests/urs.rs
@@ -44,6 +44,7 @@ fn test<E: PairingEngine>()
     let mut urs = URS::<E>::create
     (
         depth,
+        vec![3,7],
         &mut rng
     );
     println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());

--- a/marlin-succinct/protocol/src/prover.rs
+++ b/marlin-succinct/protocol/src/prover.rs
@@ -1,6 +1,6 @@
 /********************************************************************************************
 
-This source file implements prover's zk-proof primitives.
+This source file implements prover's zk-proof primitive.
 
 *********************************************************************************************/
 
@@ -438,7 +438,7 @@ impl<E: PairingEngine> ProverProof<E>
         (
             (0..index.b_group.size()).map
             (
-                |i| {crb[0][i] * &crb[1][i] * &crb[2][i]}
+                |i| crb[0][i] * &crb[1][i] * &crb[2][i]
             ).collect(),
             index.b_group
         ).interpolate();

--- a/marlin-succinct/protocol/src/prover.rs
+++ b/marlin-succinct/protocol/src/prover.rs
@@ -7,6 +7,7 @@ This source file implements prover's zk-proof primitive.
 use algebra::{Field, PairingEngine};
 use oracle::rndoracle::{RandomOracleArgument, ProofError};
 use ff_fft::{DensePolynomial, Evaluations};
+use commitment::commitment::Utils;
 use circuits::index::Index;
 
 #[derive(Clone)]
@@ -475,22 +476,5 @@ impl<F: Field> RandomOracles<F>
             batch: F::zero(),
             beta: [F::zero(), F::zero(), F::zero()],
         }
-    }
-}
-
-pub trait Scale<F: Field>
-{
-    fn scale(&self, elm: F) -> Self;
-}
-
-impl<F: Field> Scale<F> for DensePolynomial<F>
-{
-    // This function "scales" (multiplies) polynomaial with a scalar
-    // It is implemented to have the desired functionality for DensePolynomial
-    fn scale(&self, elm: F) -> Self
-    {
-        let mut result = self.clone();
-        for coeff in &mut result.coeffs {*coeff *= &elm}
-        result
     }
 }


### PR DESCRIPTION
URS G2 elements trimming. The set of URS G2 elements needed by the protocol is determined by the set of maximal degrees of the polynomials that are committed. This set of polynomials is determined by the set of circuits supported by the same instance of the URS. This commit removes all other URS G2 elements.

NOTE: the Index "constructor" creates single URS instance to support the protocol for that index. Next commits should generalize this to one URS instance being able to support multiple indexes/circuits.