### PR TITLE
change the dependencies to o1-labs versions

### DIFF
--- a/marlin-succinct/circuits/Cargo.toml
+++ b/marlin-succinct/circuits/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-algebra = { git = "https://github.com/scipr-lab/zexe/", features = [ "parallel" ] }
-ff-fft = { git = "https://github.com/scipr-lab/zexe/" }
+algebra = { git = "https://github.com/o1-labs/zexe/", features = [ "parallel" ] }
+ff-fft = { git = "https://github.com/o1-labs/zexe/" }
 commitment = { path = "../commitment" }
 oracle = { path = "../oracle" }
 rand_core = { version = "0.5" }

--- a/marlin-succinct/commitment/Cargo.toml
+++ b/marlin-succinct/commitment/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-algebra = { git = "https://github.com/scipr-lab/zexe/", features = [ "parallel" ] }
-ff-fft = { git = "https://github.com/scipr-lab/zexe/" }
+algebra = { git = "https://github.com/o1-labs/zexe/", features = [ "parallel" ] }
+ff-fft = { git = "https://github.com/o1-labs/zexe/" }
 oracle = { path = "../oracle" }
 rand_core = { version = "0.5" }
 colored = "1.9.0"

--- a/marlin-succinct/oracle/Cargo.toml
+++ b/marlin-succinct/oracle/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-algebra = { git = "https://github.com/scipr-lab/zexe/", features = [ "parallel" ] }
-ff-fft = { git = "https://github.com/scipr-lab/zexe/" }
+algebra = { git = "https://github.com/o1-labs/zexe/", features = [ "parallel" ] }
+ff-fft = { git = "https://github.com/o1-labs/zexe/" }
 rand = "0.7.2"

--- a/marlin-succinct/protocol/Cargo.toml
+++ b/marlin-succinct/protocol/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-algebra = { git = "https://github.com/scipr-lab/zexe/", features = [ "parallel" ] }
-ff-fft = { git = "https://github.com/scipr-lab/zexe/" }
+algebra = { git = "https://github.com/o1-labs/zexe/", features = [ "parallel" ] }
+ff-fft = { git = "https://github.com/o1-labs/zexe/" }
 commitment = { path = "../commitment" }
 circuits = { path = "../circuits" }
 oracle = { path = "../oracle" }


### PR DESCRIPTION
This changes all the dependencies on the algebra and ff-fft crates to the versions in the o1-labs fork of the zexe repo.