### PR TITLE
Sponge hand-off

### DIFF
--- a/marlin-succinct/circuits/src/index.rs
+++ b/marlin-succinct/circuits/src/index.rs
@@ -35,7 +35,8 @@ pub struct Index<E: PairingEngine>
     pub urs: URS<E>,
 
     // random oracle argument parameters
-    pub oracle_params: ArithmeticSpongeParams<E::Fr>,
+    pub fr_sponge_params: ArithmeticSpongeParams<E::Fr>,
+    pub fq_sponge_params: ArithmeticSpongeParams<E::Fq>,
 }
 
 impl<E: PairingEngine> Index<E>
@@ -47,7 +48,8 @@ impl<E: PairingEngine> Index<E>
         b: CsMat<E::Fr>,
         c: CsMat<E::Fr>,
         public_inputs: usize,
-        oracle_params: ArithmeticSpongeParams<E::Fr>,
+        fr_sponge_params: ArithmeticSpongeParams<E::Fr>,
+        fq_sponge_params: ArithmeticSpongeParams<E::Fq>,
         rng: &mut dyn RngCore
     ) -> Result<Self, ProofError>
     {
@@ -113,7 +115,8 @@ impl<E: PairingEngine> Index<E>
                         Compiled::<E>::compile(&urs, h_group, k_group, b_group, b)?,
                         Compiled::<E>::compile(&urs, h_group, k_group, b_group, c)?,
                     ],
-                    oracle_params,
+                    fr_sponge_params,
+                    fq_sponge_params,
                     public_inputs,
                     max_degree,
                     h_group,

--- a/marlin-succinct/protocol/src/lib.rs
+++ b/marlin-succinct/protocol/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod prover;
 pub mod verifier;
+pub mod marlin_sponge;

--- a/marlin-succinct/protocol/src/marlin_sponge.rs
+++ b/marlin-succinct/protocol/src/marlin_sponge.rs
@@ -1,0 +1,147 @@
+use crate::prover::ProofEvaluations;
+use algebra::{
+    curves::{short_weierstrass_jacobian::GroupAffine, SWModelParameters},
+    BigInteger, Field, FpParameters, PairingEngine, PrimeField,
+};
+use oracle::poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge};
+
+const DIGEST_LENGTH: usize = 256;
+const CHALLENGE_LENGTH: usize = 128;
+
+pub trait FqSponge<Fq: Field, G, Fr> {
+    fn new(p: ArithmeticSpongeParams<Fq>) -> Self;
+    fn absorb_g(&mut self, g: &G);
+    fn absorb_fr(&mut self, x: &Fr);
+    fn challenge(&mut self) -> Fr;
+
+    fn digest(self) -> Fr;
+}
+
+pub trait FrSponge<Fr: Field> {
+    fn new(p: ArithmeticSpongeParams<Fr>) -> Self;
+    fn absorb(&mut self, x: &Fr);
+    fn challenge(&mut self) -> Fr;
+    fn absorb_evaluations(&mut self, x_hat_beta1: &Fr, e: &ProofEvaluations<Fr>);
+}
+
+pub trait SpongePairingEngine: PairingEngine {
+    type FqSponge: FqSponge<Self::Fq, Self::G1Affine, Self::Fr>;
+    type FrSponge: FrSponge<Self::Fr>;
+}
+
+pub struct DefaultFqSponge<P: SWModelParameters> {
+    params: ArithmeticSpongeParams<P::BaseField>,
+    sponge: ArithmeticSponge<P::BaseField>,
+}
+
+pub struct DefaultFrSponge<Fr: Field> {
+    params: ArithmeticSpongeParams<Fr>,
+    sponge: ArithmeticSponge<Fr>,
+}
+
+impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr> {
+    fn new(params: ArithmeticSpongeParams<Fr>) -> DefaultFrSponge<Fr> {
+        DefaultFrSponge {
+            params,
+            sponge: ArithmeticSponge::new(),
+        }
+    }
+
+    fn absorb(&mut self, x: &Fr) {
+        self.sponge.absorb(&self.params, x);
+    }
+
+    fn challenge(&mut self) -> Fr {
+        let x = &self.sponge.squeeze(&self.params).into_repr().to_bits();
+
+        Fr::from_repr(Fr::BigInt::from_bits(&x[..CHALLENGE_LENGTH]))
+    }
+
+    fn absorb_evaluations(&mut self, x_hat_beta1: &Fr, e: &ProofEvaluations<Fr>) {
+        // beta1 evaluations
+        self.sponge.absorb(&self.params, x_hat_beta1);
+        for x in &[e.w, e.g1, e.h1, e.za, e.zb] {
+            self.sponge.absorb(&self.params, x);
+        }
+
+        // beta2 evaluations
+        for x in &[e.g2, e.h2] {
+            self.sponge.absorb(&self.params, x);
+        }
+
+        // beta3 evaluations
+        for x in &[e.g3, e.h3] {
+            self.sponge.absorb(&self.params, x);
+        }
+        for t in &[e.row, e.col, e.val] {
+            for x in t {
+                self.sponge.absorb(&self.params, x);
+            }
+        }
+    }
+}
+
+impl<P: SWModelParameters> FqSponge<P::BaseField, GroupAffine<P>, P::ScalarField>
+    for DefaultFqSponge<P>
+where
+    P::BaseField: PrimeField,
+    <P::BaseField as PrimeField>::BigInt: Into<<P::ScalarField as PrimeField>::BigInt>,
+{
+    fn new(params: ArithmeticSpongeParams<P::BaseField>) -> DefaultFqSponge<P> {
+        DefaultFqSponge {
+            params,
+            sponge: ArithmeticSponge::new(),
+        }
+    }
+
+    fn absorb_g(&mut self, g: &GroupAffine<P>) {
+        if g.infinity {
+            panic!("marlin sponge got zero curve point");
+        } else {
+            self.sponge.absorb(&self.params, &g.x);
+            self.sponge.absorb(&self.params, &g.y);
+        }
+    }
+
+    fn absorb_fr(&mut self, x: &P::ScalarField) {
+        let bits: Vec<bool> = x.into_repr().to_bits();
+
+        if <P::ScalarField as PrimeField>::Params::MODULUS
+            < <P::BaseField as PrimeField>::Params::MODULUS.into()
+        {
+            self.sponge.absorb(
+                &self.params,
+                &P::BaseField::from_repr(<P::BaseField as PrimeField>::BigInt::from_bits(&bits)),
+            );
+        } else {
+            let low_bits = &bits[..(bits.len() - 1)];
+            let high_bit = if bits[bits.len() - 1] {
+                P::BaseField::one()
+            } else {
+                P::BaseField::zero()
+            };
+            self.sponge.absorb(
+                &self.params,
+                &P::BaseField::from_repr(<P::BaseField as PrimeField>::BigInt::from_bits(
+                    &low_bits,
+                )),
+            );
+            self.sponge.absorb(&self.params, &high_bit);
+        }
+    }
+
+    fn digest(mut self) -> P::ScalarField {
+        let x = self.sponge.squeeze(&self.params).into_repr();
+        let x: &[bool] = &x.to_bits()[..DIGEST_LENGTH];
+        let x = <P::ScalarField as PrimeField>::BigInt::from_bits(x);
+        P::ScalarField::from_repr(x)
+    }
+
+    fn challenge(&mut self) -> P::ScalarField {
+        let x = self.sponge.squeeze(&self.params).into_repr();
+
+        P::ScalarField::from_repr(<P::ScalarField as PrimeField>::BigInt::from_bits(
+            &x.to_bits()[..CHALLENGE_LENGTH],
+        ))
+    }
+}

--- a/marlin-succinct/protocol/src/prover.rs
+++ b/marlin-succinct/protocol/src/prover.rs
@@ -57,18 +57,16 @@ pub struct ProverProof<E: PairingEngine>
     pub public: Vec<E::Fr>
 }
 
-pub trait SpongePairingEngine : PairingEngine {
-    type FqSponge : FqSponge<Self::Fq, Self::G1Affine, Self::Fr>;
-    type FrSponge : FrSponge<Self::Fr>;
-}
-
-impl<E: SpongePairingEngine> ProverProof<E>
+impl<E: PairingEngine> ProverProof<E>
 {
     // This function constructs prover's zk-proof from the witness & the Index against URS instance
     //     witness: computation witness
     //     index: Index
     //     RETURN: prover's zk-proof
     pub fn create
+        <EFqSponge: FqSponge<E::Fq, E::G1Affine, E::Fr>,
+         EFrSponge: FrSponge<E::Fr>,
+        >
     (
         witness: &Vec::<E::Fr>,
         index: &Index<E>
@@ -134,7 +132,7 @@ impl<E: SpongePairingEngine> ProverProof<E>
         let zb_comm = index.urs.commit(&zb.clone(), index.h_group.size())?;
 
         // the transcript of the random oracle non-interactive argument
-        let mut fq_sponge = E::FqSponge::new(index.fq_sponge_params.clone());
+        let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
 
         // absorb previous proof context into the argument
         fq_sponge.absorb_fr(&E::Fr::one());
@@ -214,7 +212,7 @@ impl<E: SpongePairingEngine> ProverProof<E>
 
         let mut fr_sponge = {
             let digest_before_evaluations = fq_sponge.digest();
-            let mut s = E::FrSponge::new(index.fr_sponge_params.clone());
+            let mut s = EFrSponge::new(index.fr_sponge_params.clone());
             s.absorb(&digest_before_evaluations);
             s
         };

--- a/marlin-succinct/protocol/src/prover.rs
+++ b/marlin-succinct/protocol/src/prover.rs
@@ -5,10 +5,27 @@ This source file implements prover's zk-proof primitive.
 *********************************************************************************************/
 
 use algebra::{Field, PairingEngine};
-use oracle::rndoracle::{RandomOracleArgument, ProofError};
+use oracle::rndoracle::{ProofError};
 use ff_fft::{DensePolynomial, Evaluations};
 use commitment::commitment::Utils;
 use circuits::index::Index;
+use crate::marlin_sponge::{FqSponge, FrSponge};
+
+#[derive(Clone)]
+pub struct ProofEvaluations<Fr> {
+    pub w: Fr,
+    pub za: Fr,
+    pub zb: Fr,
+    pub h1: Fr,
+    pub g1: Fr,
+    pub h2: Fr,
+    pub g2: Fr,
+    pub h3: Fr,
+    pub g3: Fr,
+    pub row: [Fr; 3],
+    pub col: [Fr; 3],
+    pub val: [Fr; 3],
+}
 
 #[derive(Clone)]
 pub struct ProverProof<E: PairingEngine>
@@ -30,18 +47,7 @@ pub struct ProverProof<E: PairingEngine>
     pub proof3: E::G1Affine,
 
     // polynomial evaluations
-    pub w_eval: E::Fr,
-    pub za_eval: E::Fr,
-    pub zb_eval: E::Fr,
-    pub h1_eval: E::Fr,
-    pub g1_eval: E::Fr,
-    pub h2_eval: E::Fr,
-    pub g2_eval: E::Fr,
-    pub h3_eval: E::Fr,
-    pub g3_eval: E::Fr,
-    pub row_eval: [E::Fr; 3],
-    pub col_eval: [E::Fr; 3],
-    pub val_eval: [E::Fr; 3],
+    pub evals : ProofEvaluations<E::Fr>,
 
     // prover's scalars
     pub sigma2: E::Fr,
@@ -51,7 +57,12 @@ pub struct ProverProof<E: PairingEngine>
     pub public: Vec<E::Fr>
 }
 
-impl<E: PairingEngine> ProverProof<E>
+pub trait SpongePairingEngine : PairingEngine {
+    type FqSponge : FqSponge<Self::Fq, Self::G1Affine, Self::Fr>;
+    type FrSponge : FrSponge<Self::Fr>;
+}
+
+impl<E: SpongePairingEngine> ProverProof<E>
 {
     // This function constructs prover's zk-proof from the witness & the Index against URS instance
     //     witness: computation witness
@@ -106,6 +117,10 @@ impl<E: PairingEngine> ProverProof<E>
             }
         }
 
+        let x_hat = 
+            Evaluations::<E::Fr>::from_vec_and_domain(public.clone(), index.x_group).interpolate();
+        let x_hat_comm = index.urs.exponentiate(&x_hat)?;
+
         // prover interpolates the vectors and computes the evaluation polynomial
         let za = Evaluations::<E::Fr>::from_vec_and_domain(zv[0].to_vec(), index.h_group).interpolate();
         let zb = Evaluations::<E::Fr>::from_vec_and_domain(zv[1].to_vec(), index.h_group).interpolate();
@@ -119,20 +134,22 @@ impl<E: PairingEngine> ProverProof<E>
         let zb_comm = index.urs.commit(&zb.clone(), index.h_group.size())?;
 
         // the transcript of the random oracle non-interactive argument
-        let mut argument = RandomOracleArgument::<E>::new(index.oracle_params.clone());
-        
+        let mut fq_sponge = E::FqSponge::new(index.fq_sponge_params.clone());
+
         // absorb previous proof context into the argument
-        argument.commit_scalars(&[E::Fr::one()]);
+        fq_sponge.absorb_fr(&E::Fr::one());
         // absorb the public input into the argument
-        argument.commit_scalars(&public[..]);
+        fq_sponge.absorb_g(& x_hat_comm);
         // absorb W, ZA, ZB polycommitments
-        argument.commit_points(&[w_comm, za_comm, zb_comm])?;
+        fq_sponge.absorb_g(& w_comm);
+        fq_sponge.absorb_g(& za_comm);
+        fq_sponge.absorb_g(& zb_comm);
 
         // sample alpha, eta oracles
-        oracles.alpha = argument.challenge();
-        oracles.eta_a = argument.challenge();
-        oracles.eta_b = argument.challenge();
-        oracles.eta_c = argument.challenge();
+        oracles.alpha = fq_sponge.challenge();
+        oracles.eta_a = fq_sponge.challenge();
+        oracles.eta_b = fq_sponge.challenge();
+        oracles.eta_c = fq_sponge.challenge();
 
         let mut apow = E::Fr::one();
         let mut r: Vec<E::Fr> = (0..index.h_group.size()).map
@@ -158,9 +175,10 @@ impl<E: PairingEngine> ProverProof<E>
         let g1_comm = index.urs.commit(&g1, index.h_group.size()-1)?;
 
         // absorb H1, G1 polycommitments
-        argument.commit_points(&[h1_comm, g1_comm])?;
+        fq_sponge.absorb_g(&g1_comm);
+        fq_sponge.absorb_g(&h1_comm);
         // sample beta[0] oracle
-        oracles.beta[0] = argument.challenge();
+        oracles.beta[0] = fq_sponge.challenge();
 
         // compute second sumcheck argument polynomials
         // --------------------------------------------------------------------
@@ -168,11 +186,15 @@ impl<E: PairingEngine> ProverProof<E>
         let (h2, mut g2) = Self::sumcheck_2_compute (index, &ra, &oracles)?;
         let sigma2 = g2.coeffs[0];
         g2.coeffs.remove(0);
+        let h2_comm = index.urs.commit(&h2, index.h_group.size()-1)?;
+        let g2_comm = index.urs.commit(&g2, index.h_group.size()-1)?;
 
-        // absorb sigma2 scalar
-        argument.commit_scalars(&[sigma2]);
+        // absorb sigma2, g2, h2
+        fq_sponge.absorb_fr(&sigma2);
+        fq_sponge.absorb_g(&g2_comm);
+        fq_sponge.absorb_g(&h2_comm);
         // sample beta[1] oracle
-        oracles.beta[1] = argument.challenge();
+        oracles.beta[1] = fq_sponge.challenge();
 
         // compute third sumcheck argument polynomials
         // --------------------------------------------------------------------
@@ -180,12 +202,56 @@ impl<E: PairingEngine> ProverProof<E>
         let (h3, mut g3) = Self::sumcheck_3_compute (index, &oracles)?;
         let sigma3 = g3.coeffs[0];
         g3.coeffs.remove(0);
+        let h3_comm = index.urs.commit(&h3, index.k_group.size()*6-6)?;
+        let g3_comm = index.urs.commit(&g3, index.k_group.size()-1)?;
 
-        // absorb sigma3 scalar
-        argument.commit_scalars(&[sigma3]);
+        // absorb sigma3, g3, h3
+        fq_sponge.absorb_fr(&sigma3);
+        fq_sponge.absorb_g(&g3_comm);
+        fq_sponge.absorb_g(&h3_comm);
         // sample beta[2] & batch oracles
-        oracles.beta[2] = argument.challenge();
-        oracles.batch = argument.challenge();
+        oracles.beta[2] = fq_sponge.challenge();
+
+        let mut fr_sponge = {
+            let digest_before_evaluations = fq_sponge.digest();
+            let mut s = E::FrSponge::new(index.fr_sponge_params.clone());
+            s.absorb(&digest_before_evaluations);
+            s
+        };
+
+        let evals = ProofEvaluations {
+            w  : w.evaluate(oracles.beta[0]),
+            za : za.evaluate(oracles.beta[0]),
+            zb : zb.evaluate(oracles.beta[0]),
+            h1 : h1.evaluate(oracles.beta[0]),
+            g1 : g1.evaluate(oracles.beta[0]),
+            h2 : h2.evaluate(oracles.beta[1]),
+            g2 : g2.evaluate(oracles.beta[1]),
+            h3 : h3.evaluate(oracles.beta[2]),
+            g3 : g3.evaluate(oracles.beta[2]),
+            row:
+            [
+                index.compiled[0].row.evaluate(oracles.beta[2]),
+                index.compiled[1].row.evaluate(oracles.beta[2]),
+                index.compiled[2].row.evaluate(oracles.beta[2]),
+            ],
+            col:
+            [
+                index.compiled[0].col.evaluate(oracles.beta[2]),
+                index.compiled[1].col.evaluate(oracles.beta[2]),
+                index.compiled[2].col.evaluate(oracles.beta[2]),
+            ],
+            val:
+            [
+                index.compiled[0].val.evaluate(oracles.beta[2]),
+                index.compiled[1].val.evaluate(oracles.beta[2]),
+                index.compiled[2].val.evaluate(oracles.beta[2]),
+            ],
+        };
+
+        fr_sponge.absorb_evaluations(&x_hat.evaluate(oracles.beta[0]),&evals);
+
+        oracles.batch = fr_sponge.challenge();
 
         // construct the proof
         // --------------------------------------------------------------------
@@ -198,8 +264,8 @@ impl<E: PairingEngine> ProverProof<E>
             zb_comm,
             h1_comm,
             g1_comm,
-            h2_comm: index.urs.commit(&h2, index.h_group.size()-1)?,
-            g2_comm: index.urs.commit(&g2, index.h_group.size()-1)?,
+            h2_comm,
+            g2_comm,
             h3_comm: index.urs.commit(&h3, index.k_group.size()*6-6)?,
             g3_comm: index.urs.commit(&g3, index.k_group.size()-1)?,
 
@@ -248,33 +314,7 @@ impl<E: PairingEngine> ProverProof<E>
             )?,
 
             // polynomial evaluations
-            w_eval  : w.evaluate(oracles.beta[0]),
-            za_eval : za.evaluate(oracles.beta[0]),
-            zb_eval : zb.evaluate(oracles.beta[0]),
-            h1_eval : h1.evaluate(oracles.beta[0]),
-            g1_eval : g1.evaluate(oracles.beta[0]),
-            h2_eval : h2.evaluate(oracles.beta[1]),
-            g2_eval : g2.evaluate(oracles.beta[1]),
-            h3_eval : h3.evaluate(oracles.beta[2]),
-            g3_eval : g3.evaluate(oracles.beta[2]),
-            row_eval:
-            [
-                index.compiled[0].row.evaluate(oracles.beta[2]),
-                index.compiled[1].row.evaluate(oracles.beta[2]),
-                index.compiled[2].row.evaluate(oracles.beta[2]),
-            ],
-            col_eval:
-            [
-                index.compiled[0].col.evaluate(oracles.beta[2]),
-                index.compiled[1].col.evaluate(oracles.beta[2]),
-                index.compiled[2].col.evaluate(oracles.beta[2]),
-            ],
-            val_eval:
-            [
-                index.compiled[0].val.evaluate(oracles.beta[2]),
-                index.compiled[1].val.evaluate(oracles.beta[2]),
-                index.compiled[2].val.evaluate(oracles.beta[2]),
-            ],
+            evals,
 
             // prover's scalars
             sigma2,

--- a/marlin-succinct/protocol/src/verifier.rs
+++ b/marlin-succinct/protocol/src/verifier.rs
@@ -229,10 +229,14 @@ impl<E: SpongePairingEngine> ProverProof<E>
         oracles.beta[0] = fq_sponge.challenge();
         // absorb sigma2 scalar
         fq_sponge.absorb_fr(&self.sigma2);
+        fq_sponge.absorb_g(&self.g2_comm);
+        fq_sponge.absorb_g(&self.h2_comm);
         // sample beta[1] oracle
         oracles.beta[1] = fq_sponge.challenge();
         // absorb sigma3 scalar
         fq_sponge.absorb_fr(&self.sigma3);
+        fq_sponge.absorb_g(&self.g3_comm);
+        fq_sponge.absorb_g(&self.h3_comm);
         // sample beta[2] & batch oracles
         oracles.beta[2] = fq_sponge.challenge();
 

--- a/marlin-succinct/protocol/src/verifier.rs
+++ b/marlin-succinct/protocol/src/verifier.rs
@@ -6,12 +6,13 @@ This source file implements zk-proof batch verifier functionality.
 
 use rand_core::RngCore;
 use circuits::index::Index;
-use oracle::rndoracle::{ProofError, RandomOracleArgument};
-pub use super::prover::{ProverProof, RandomOracles};
-use algebra::{Field, PairingEngine};
+use oracle::rndoracle::{ProofError};
+pub use super::prover::{ProverProof, RandomOracles, SpongePairingEngine};
+use algebra::{Field};
 use ff_fft::Evaluations;
+use crate::marlin_sponge::{FqSponge, FrSponge};
 
-impl<E: PairingEngine> ProverProof<E>
+impl<E: SpongePairingEngine> ProverProof<E>
 {
     // This function verifies the prover's first sumcheck argument values
     //     index: Index
@@ -32,9 +33,9 @@ impl<E: PairingEngine> ProverProof<E>
                 {
                     match i
                     {
-                        0 => {self.za_eval * &oracles.eta_a}
-                        1 => {self.zb_eval * &oracles.eta_b}
-                        2 => {self.za_eval * &self.zb_eval * &oracles.eta_c}
+                        0 => {self.evals.za * &oracles.eta_a}
+                        1 => {self.evals.zb * &oracles.eta_b}
+                        2 => {self.evals.za * &self.evals.zb * &oracles.eta_c}
                         _ => {E::Fr::zero()}
                     }
                 }
@@ -42,10 +43,10 @@ impl<E: PairingEngine> ProverProof<E>
         ==
         (oracles.alpha - &oracles.beta[0]) *
         &(
-            self.h1_eval * &index.h_group.evaluate_vanishing_polynomial(oracles.beta[0]) +
-            &(oracles.beta[0] * &self.g1_eval) +
+            self.evals.h1 * &index.h_group.evaluate_vanishing_polynomial(oracles.beta[0]) +
+            &(oracles.beta[0] * &self.evals.g1) +
             &(self.sigma2 * &index.h_group.size_as_field_element *
-            &(self.w_eval * &index.x_group.evaluate_vanishing_polynomial(oracles.beta[0]) +
+            &(self.evals.w * &index.x_group.evaluate_vanishing_polynomial(oracles.beta[0]) +
             // interpolating/evaluating public input over small domain x_group
             // TODO: investigate which of the below is faster
             &Evaluations::<E::Fr>::from_vec_and_domain(self.public.clone(), index.x_group).interpolate().evaluate(oracles.beta[0])))
@@ -73,9 +74,9 @@ impl<E: PairingEngine> ProverProof<E>
         self.sigma3 * &index.k_group.size_as_field_element *
             &((oracles.alpha.pow([index.h_group.size]) - &oracles.beta[1].pow([index.h_group.size])))
         ==
-        (oracles.alpha - &oracles.beta[1]) * &(self.h2_eval *
+        (oracles.alpha - &oracles.beta[1]) * &(self.evals.h2 *
             &index.h_group.evaluate_vanishing_polynomial(oracles.beta[1]) +
-            &self.sigma2 + &(self.g2_eval * &oracles.beta[1]))
+            &self.sigma2 + &(self.evals.g2 * &oracles.beta[1]))
     }
 
     // This function verifies the prover's third sumcheck argument values
@@ -91,24 +92,24 @@ impl<E: PairingEngine> ProverProof<E>
     {
         let crb: Vec<E::Fr> = (0..3).map
         (
-            |i| {(oracles.beta[1] - &self.row_eval[i]) * &(oracles.beta[0] - &self.col_eval[i])}
+            |i| {(oracles.beta[1] - &self.evals.row[i]) * &(oracles.beta[0] - &self.evals.col[i])}
         ).collect();
 
         let acc = (0..3).map
         (
             |i|
             {
-                let mut x = self.val_eval[i] * &[oracles.eta_a, oracles.eta_b, oracles.eta_c][i];
+                let mut x = self.evals.val[i] * &[oracles.eta_a, oracles.eta_b, oracles.eta_c][i];
                 for j in 0..3 {if i != j {x *= &crb[j]}}
                 x
             }
         ).fold(E::Fr::zero(), |x, y| x + &y);
 
-        index.k_group.evaluate_vanishing_polynomial(oracles.beta[2]) * &self.h3_eval
+        index.k_group.evaluate_vanishing_polynomial(oracles.beta[2]) * &self.evals.h3
         ==
         index.h_group.evaluate_vanishing_polynomial(oracles.beta[0]) *
             &(index.h_group.evaluate_vanishing_polynomial(oracles.beta[1])) *
-            &acc - &((oracles.beta[2] * &self.g3_eval + &self.sigma3) *
+            &acc - &((oracles.beta[2] * &self.evals.g3 + &self.sigma3) *
             &crb[0] * &crb[1] * &crb[2])
     }
 
@@ -145,11 +146,11 @@ impl<E: PairingEngine> ProverProof<E>
                 oracles.batch,
                 vec!
                 [
-                    (proof.za_comm, proof.za_eval, index.h_group.size()),
-                    (proof.zb_comm, proof.zb_eval, index.h_group.size()),
-                    (proof.w_comm,  proof.w_eval,  index.h_group.size() - index.x_group.size()),
-                    (proof.h1_comm, proof.h1_eval, index.h_group.size()*2-2),
-                    (proof.g1_comm, proof.g1_eval, index.h_group.size()-1),
+                    (proof.za_comm, proof.evals.za, index.h_group.size()),
+                    (proof.zb_comm, proof.evals.zb, index.h_group.size()),
+                    (proof.w_comm,  proof.evals.w,  index.h_group.size() - index.x_group.size()),
+                    (proof.h1_comm, proof.evals.h1, index.h_group.size()*2-2),
+                    (proof.g1_comm, proof.evals.g1, index.h_group.size()-1),
                 ],
                 proof.proof1
             ));
@@ -159,8 +160,8 @@ impl<E: PairingEngine> ProverProof<E>
                 oracles.batch,
                 vec!
                 [
-                    (proof.h2_comm, proof.h2_eval, index.h_group.size()-1),
-                    (proof.g2_comm, proof.g2_eval, index.h_group.size()-1),
+                    (proof.h2_comm, proof.evals.h2, index.h_group.size()-1),
+                    (proof.g2_comm, proof.evals.g2, index.h_group.size()-1),
                 ],
                 proof.proof2
             ));
@@ -170,17 +171,17 @@ impl<E: PairingEngine> ProverProof<E>
                 oracles.batch,
                 vec!
                 [
-                    (proof.h3_comm, proof.h3_eval, index.k_group.size()*6-6),
-                    (proof.g3_comm, proof.g3_eval, index.k_group.size()-1),
-                    (index.compiled[0].row_comm, proof.row_eval[0], index.k_group.size()),
-                    (index.compiled[1].row_comm, proof.row_eval[1], index.k_group.size()),
-                    (index.compiled[2].row_comm, proof.row_eval[2], index.k_group.size()),
-                    (index.compiled[0].col_comm, proof.col_eval[0], index.k_group.size()),
-                    (index.compiled[1].col_comm, proof.col_eval[1], index.k_group.size()),
-                    (index.compiled[2].col_comm, proof.col_eval[2], index.k_group.size()),
-                    (index.compiled[0].val_comm, proof.val_eval[0], index.k_group.size()),
-                    (index.compiled[1].val_comm, proof.val_eval[1], index.k_group.size()),
-                    (index.compiled[2].val_comm, proof.val_eval[2], index.k_group.size()),
+                    (proof.h3_comm, proof.evals.h3, index.k_group.size()*6-6),
+                    (proof.g3_comm, proof.evals.g3, index.k_group.size()-1),
+                    (index.compiled[0].row_comm, proof.evals.row[0], index.k_group.size()),
+                    (index.compiled[1].row_comm, proof.evals.row[1], index.k_group.size()),
+                    (index.compiled[2].row_comm, proof.evals.row[2], index.k_group.size()),
+                    (index.compiled[0].col_comm, proof.evals.col[0], index.k_group.size()),
+                    (index.compiled[1].col_comm, proof.evals.col[1], index.k_group.size()),
+                    (index.compiled[2].col_comm, proof.evals.col[2], index.k_group.size()),
+                    (index.compiled[0].val_comm, proof.evals.val[0], index.k_group.size()),
+                    (index.compiled[1].val_comm, proof.evals.val[1], index.k_group.size()),
+                    (index.compiled[2].val_comm, proof.evals.val[2], index.k_group.size()),
                 ],
                 proof.proof3
             ));
@@ -202,32 +203,49 @@ impl<E: PairingEngine> ProverProof<E>
     ) -> Result<RandomOracles<E::Fr>, ProofError>
     {
         let mut oracles = RandomOracles::<E::Fr>::zero();
-        let mut argument = RandomOracleArgument::<E>::new(index.oracle_params.clone());
+        let mut fq_sponge = E::FqSponge::new(index.fq_sponge_params.clone());
 
-        // absorb previous proof context into the argument
-        argument.commit_scalars(&[E::Fr::one()]);
+        // TODO: absorb previous proof context into the argument
+        fq_sponge.absorb_fr(&E::Fr::one());
         // absorb the public input into the argument
-        argument.commit_scalars(&self.public[..]);
+        let x_hat =
+            // TODO: Cache this interpolated polynomial.
+            Evaluations::<E::Fr>::from_vec_and_domain(self.public.clone(), index.x_group).interpolate();
+        let x_hat_comm = index.urs.exponentiate(&x_hat)?;
+        fq_sponge.absorb_g(&x_hat_comm);
         // absorb W, ZA, ZB polycommitments
-        argument.commit_points(&[self.w_comm, self.za_comm, self.zb_comm])?;
+        fq_sponge.absorb_g(& self.w_comm);
+        fq_sponge.absorb_g(& self.za_comm);
+        fq_sponge.absorb_g(& self.zb_comm);
         // sample alpha, eta[0..3] oracles
-        oracles.alpha = argument.challenge();
-        oracles.eta_a = argument.challenge();
-        oracles.eta_b = argument.challenge();
-        oracles.eta_c = argument.challenge();
+        oracles.alpha = fq_sponge.challenge();
+        oracles.eta_a = fq_sponge.challenge();
+        oracles.eta_b = fq_sponge.challenge();
+        oracles.eta_c = fq_sponge.challenge();
         // absorb H1, G1 polycommitments
-        argument.commit_points(&[self.h1_comm, self.g1_comm])?;
+        fq_sponge.absorb_g(&self.g1_comm);
+        fq_sponge.absorb_g(&self.h1_comm);
         // sample beta[0] oracle
-        oracles.beta[0] = argument.challenge();
+        oracles.beta[0] = fq_sponge.challenge();
         // absorb sigma2 scalar
-        argument.commit_scalars(&[self.sigma2]);
+        fq_sponge.absorb_fr(&self.sigma2);
         // sample beta[1] oracle
-        oracles.beta[1] = argument.challenge();
+        oracles.beta[1] = fq_sponge.challenge();
         // absorb sigma3 scalar
-        argument.commit_scalars(&[self.sigma3]);
+        fq_sponge.absorb_fr(&self.sigma3);
         // sample beta[2] & batch oracles
-        oracles.beta[2] = argument.challenge();
-        oracles.batch = argument.challenge();
+        oracles.beta[2] = fq_sponge.challenge();
+
+        let mut fr_sponge = {
+            let digest_before_evaluations = fq_sponge.digest();
+            let mut s = E::FrSponge::new(index.fr_sponge_params.clone());
+            s.absorb(&digest_before_evaluations);
+            s
+        };
+
+        fr_sponge.absorb_evaluations(&x_hat.evaluate(oracles.beta[0]),&self.evals);
+
+        oracles.batch = fr_sponge.challenge();
 
         Ok(oracles)
     }


### PR DESCRIPTION
This PR changes the sponges used to reflect the usage in the snarky implementation. It is done this way for efficiency of the verifier circuit. The way it works is as follows.

- Before the prover sends their evaluations, we use a `BaseField`-based sponge
- After the prover sends their evaluations, we switch to using a `ScalarField` based sponge, initializing it with a digest from the `BaseField` based sponge.

I also did the following:
- The prover's evaluations are factored out into a struct. This was useful for absorbing the evaluations into the sponge, and will also be useful in reusing code with the DLog-based Marlin, since the batching in that protocol causes the evaluations data to be quite different (we require an evaluation of every polynomial on every point). 
- Challenges are now truncated to 128 bits.