### PR TITLE
separate out verifier index

### DIFF
--- a/marlin-succinct/circuits/src/index.rs
+++ b/marlin-succinct/circuits/src/index.rs
@@ -13,7 +13,6 @@ use oracle::rndoracle::ProofError;
 use oracle::poseidon::ArithmeticSpongeParams;
 pub use super::compiled::Compiled;
 pub use super::gate::CircuitGate;
-use std::collections::HashMap;
 
 pub struct Index<E: PairingEngine>
 {
@@ -90,7 +89,7 @@ impl<E: PairingEngine> Index<E>
             URS::<E> {
                 gp,
                 // TODO: We just need (beta^{N - (h_group.size() - 1)}) and (beta^{N - (k_group.size() - 1)})
-                hn : HashMap::new(),
+                hn : self.urs.hn.clone(),
                 hx: self.urs.hx,
                 prf: self.urs.prf
             }

--- a/marlin-succinct/commitment/src/commitment.rs
+++ b/marlin-succinct/commitment/src/commitment.rs
@@ -63,6 +63,23 @@ impl<E: PairingEngine> URS<E>
         ).into_affine())
     }
 
+    pub fn exponentiate_sub_domain
+    (
+        &self,
+        plnm: &DensePolynomial<E::Fr>,
+        ratio : usize,
+    ) -> Result<E::G1Affine, ProofError>
+    {
+        if plnm.coeffs.len() > self.gp.len() {return Err(ProofError::PolyExponentiate)}
+
+        Ok(VariableBaseMSM::multi_scalar_mul
+        (
+            &(0..plnm.len()).map(|i| self.gp[ratio * i]).collect::<Vec<_>>(),
+            &plnm.coeffs.iter().map(|s| s.into_repr()).collect::<Vec<_>>()
+        ).into_affine())
+    }
+
+
     // This function opens the polynomial commitment
     //     elm: base field element to open the commitment at
     //     plnm: commited polynomial

--- a/marlin-succinct/protocol/src/prover.rs
+++ b/marlin-succinct/protocol/src/prover.rs
@@ -117,7 +117,7 @@ impl<E: PairingEngine> ProverProof<E>
 
         let x_hat = 
             Evaluations::<E::Fr>::from_vec_and_domain(public.clone(), index.x_group).interpolate();
-        let x_hat_comm = index.urs.exponentiate(&x_hat)?;
+        let x_hat_comm = index.urs.exponentiate_sub_domain(&x_hat, ratio)?;
 
         // prover interpolates the vectors and computes the evaluation polynomial
         let za = Evaluations::<E::Fr>::from_vec_and_domain(zv[0].to_vec(), index.h_group).interpolate();

--- a/marlin-succinct/protocol/src/verifier.rs
+++ b/marlin-succinct/protocol/src/verifier.rs
@@ -5,7 +5,7 @@ This source file implements zk-proof batch verifier functionality.
 *********************************************************************************************/
 
 use rand_core::RngCore;
-use circuits::index::Index;
+use circuits::index::{VerifierIndex as Index};
 use oracle::rndoracle::{ProofError};
 pub use super::prover::{ProverProof, RandomOracles};
 use algebra::{Field, PairingEngine};
@@ -176,15 +176,15 @@ impl<E: PairingEngine> ProverProof<E>
                 [
                     (proof.h3_comm, proof.evals.h3, index.k_group.size()*6-6),
                     (proof.g3_comm, proof.evals.g3, index.k_group.size()-1),
-                    (index.compiled[0].row_comm, proof.evals.row[0], index.k_group.size()),
-                    (index.compiled[1].row_comm, proof.evals.row[1], index.k_group.size()),
-                    (index.compiled[2].row_comm, proof.evals.row[2], index.k_group.size()),
-                    (index.compiled[0].col_comm, proof.evals.col[0], index.k_group.size()),
-                    (index.compiled[1].col_comm, proof.evals.col[1], index.k_group.size()),
-                    (index.compiled[2].col_comm, proof.evals.col[2], index.k_group.size()),
-                    (index.compiled[0].val_comm, proof.evals.val[0], index.k_group.size()),
-                    (index.compiled[1].val_comm, proof.evals.val[1], index.k_group.size()),
-                    (index.compiled[2].val_comm, proof.evals.val[2], index.k_group.size()),
+                    (index.matrix_commitments[0].row, proof.evals.row[0], index.k_group.size()),
+                    (index.matrix_commitments[1].row, proof.evals.row[1], index.k_group.size()),
+                    (index.matrix_commitments[2].row, proof.evals.row[2], index.k_group.size()),
+                    (index.matrix_commitments[0].col, proof.evals.col[0], index.k_group.size()),
+                    (index.matrix_commitments[1].col, proof.evals.col[1], index.k_group.size()),
+                    (index.matrix_commitments[2].col, proof.evals.col[2], index.k_group.size()),
+                    (index.matrix_commitments[0].val, proof.evals.val[0], index.k_group.size()),
+                    (index.matrix_commitments[1].val, proof.evals.val[1], index.k_group.size()),
+                    (index.matrix_commitments[2].val, proof.evals.val[2], index.k_group.size()),
                 ],
                 proof.proof3
             ));


### PR DESCRIPTION
This PR makes a separate verifier index which only contains those values that are needed by the verifier. The one thing that still needs to be done is only taking the subset of G2 elements from the index that are needed for the degree checks, but I figured that could be done after the degree-bounded verifier is implemented.