### PR TITLE
change alpha to 17 to improve sponge performance

### DIFF
--- a/marlin-dlog/oracle/src/poseidon.rs
+++ b/marlin-dlog/oracle/src/poseidon.rs
@@ -10,7 +10,7 @@ It implements Poseidon Hash Function primitive
 use algebra::Field;
 
 pub const ROUNDS_FULL: usize = 8;
-pub const ROUNDS_PARTIAL: usize = 33;
+pub const ROUNDS_PARTIAL: usize = 25;
 const HALF_ROUNDS_FULL: usize = ROUNDS_FULL / 2;
 pub const SPONGE_CAPACITY: usize = 1;
 pub const SPONGE_RATE: usize = 2;
@@ -22,12 +22,14 @@ pub trait Sponge<Input, Digest> {
     fn squeeze(&mut self, params: &Self::Params) -> Digest;
 }
 
-// x^5
+// x^17
 fn sbox<F: Field>(x: F) -> F {
     let mut res = x;
     res.square_in_place(); //x^2
     res.square_in_place(); //x^4
-    res.mul_assign(&x);
+    res.square_in_place(); //x^8
+    res.square_in_place(); //x^16
+    res.mul_assign(&x); // x^17
     res
 }
 

--- a/marlin-succinct/oracle/src/poseidon.rs
+++ b/marlin-succinct/oracle/src/poseidon.rs
@@ -10,7 +10,7 @@ It implements Poseidon Hash Function primitive
 use algebra::Field;
 
 pub const ROUNDS_FULL: usize = 8;
-pub const ROUNDS_PARTIAL: usize = 33;
+pub const ROUNDS_PARTIAL: usize = 25;
 const HALF_ROUNDS_FULL: usize = ROUNDS_FULL / 2;
 pub const SPONGE_CAPACITY: usize = 1;
 pub const SPONGE_RATE: usize = 2;
@@ -22,12 +22,14 @@ pub trait Sponge<Input, Digest> {
     fn squeeze(&mut self, params: &Self::Params) -> Digest;
 }
 
-// x^5
+// x^17
 fn sbox<F: Field>(x: F) -> F {
     let mut res = x;
     res.square_in_place(); //x^2
     res.square_in_place(); //x^4
-    res.mul_assign(&x);
+    res.square_in_place(); //x^8
+    res.square_in_place(); //x^16
+    res.mul_assign(&x); // x^17
     res
 }
 

--- a/sponge_cost.sage
+++ b/sponge_cost.sage
@@ -1,0 +1,20 @@
+import math
+
+def grobner_complexity(state_size, alpha, rounds_full, rounds_partial):
+    num_vars = (state_size - 1) * rounds_full + rounds_partial
+    num_equations = num_vars
+    d_reg = (1 + num_equations * (alpha - 1)) // 2
+    return math.log(binomial(num_vars + d_reg, d_reg) ** 2, 2)
+
+security = 128
+
+def interpolation_rounds_lower_bound(state_size, alpha):
+    return 1 + security * math.log(2, alpha) + math.log(state_size, alpha)
+
+rounds_full = 8
+rounds_partial = 25
+state_size = 3 # the state size
+alpha = 17
+
+assert (rounds_full + rounds_partial >= interpolation_rounds_lower_bound(state_size, alpha))
+assert (security <= grobner_complexity(state_size, alpha, rounds_full, rounds_partial))


### PR DESCRIPTION
This PR implements a suggestion of @ValarDragon, namely changing alpha to 17 in the Poseidon sbox, which allows us to reduce the number of rounds and improve overall performance. 

The overall performance of the Fq-circuit is as follows for various values of alpha:

alpha=17, dlog main. rounds_partial=26, rounds_full=8
weights 205781 205780 205653

alpha=13, dlog main, rounds_partial=31, rounds_full=8
weights 210409 210409 210279

alpha=11, dlog main, rounds_partial=31, rounds_full=8
weights 213400 213399 213272

alpha=5, dlog main. rounds_partial=49, rounds_full=8
weights 214509 214508 214381

The previous number of rounds was in fact not sufficient for security.