### PR TITLE
Split out eval domains for dlog proof

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "dlog",
     "pairing",
     "oracle",
+    "evaluation_domains",
 ]
 
 [profile.release]

--- a/dlog/circuits/Cargo.toml
+++ b/dlog/circuits/Cargo.toml
@@ -11,6 +11,7 @@ algebra = { git = "https://github.com/o1-labs/zexe/", features = [ "parallel" ] 
 ff-fft = { git = "https://github.com/o1-labs/zexe/" }
 commitment_dlog = { path = "../commitment" }
 oracle = { path = "../../oracle" }
+evaluation_domains = { path = "../../evaluation_domains" }
 rand_core = { version = "0.5" }
 colored = "1.9.2"
 rand = "0.7.3"

--- a/dlog/tests/group_addition.rs
+++ b/dlog/tests/group_addition.rs
@@ -21,7 +21,7 @@ of non-special pairs of points
 
 **********************************************************************************************************/
 
-use circuits_dlog::index::Index;
+use circuits_dlog::index::{SRSSpec, Index};
 use sprs::{CsMat, CsVecView};
 use algebra::{curves::{bn_382::g::{Affine, Bn_382GParameters}}, AffineCurve, Field};
 use protocol_dlog::{prover::{ProverProof}, marlin_sponge::{DefaultFqSponge, DefaultFrSponge}};
@@ -72,7 +72,7 @@ fn group_addition()
         4,
         oracle::bn_382::fq::params() as ArithmeticSpongeParams<Fr>,
         oracle::bn_382::fp::params(),
-        rng
+        SRSSpec::Generate(rng)
     ).unwrap();
 
     positive(&index, rng);

--- a/evaluation_domains/Cargo.toml
+++ b/evaluation_domains/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "evaluation_domains"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+algebra = { git = "https://github.com/o1-labs/zexe/", features = [ "parallel" ] }
+ff-fft = { git = "https://github.com/o1-labs/zexe/" }

--- a/evaluation_domains/src/lib.rs
+++ b/evaluation_domains/src/lib.rs
@@ -1,0 +1,32 @@
+use algebra::PrimeField;
+use ff_fft::EvaluationDomain;
+
+#[derive(Debug, Clone, Copy)]
+pub struct EvaluationDomains<F : PrimeField> {
+    pub h: EvaluationDomain<F>,
+    pub k: EvaluationDomain<F>,
+    pub b: EvaluationDomain<F>,
+    pub x: EvaluationDomain<F>,
+}
+
+impl<F : PrimeField> EvaluationDomains<F> {
+    pub fn create(
+        variables : usize,
+        public_inputs: usize,
+        nonzero_entries: usize) -> Option<Self> {
+
+        let h_group_size = 
+            EvaluationDomain::<F>::compute_size_of_domain(variables)?;
+        let x_group_size =
+            EvaluationDomain::<F>::compute_size_of_domain(public_inputs)?;
+        let k_group_size =
+            EvaluationDomain::<F>::compute_size_of_domain(nonzero_entries)?;
+
+        let h = EvaluationDomain::<F>::new(h_group_size)?;
+        let k = EvaluationDomain::<F>::new(k_group_size)?;
+        let b = EvaluationDomain::<F>::new(k_group_size * 3 - 3)?;
+        let x = EvaluationDomain::<F>::new(x_group_size)?;
+
+        Some (EvaluationDomains { h, k, b, x })
+    }
+}

--- a/pairing/circuits/Cargo.toml
+++ b/pairing/circuits/Cargo.toml
@@ -15,3 +15,4 @@ rand_core = { version = "0.5" }
 colored = "1.9.2"
 rand = "0.7.3"
 sprs = "0.7.1"
+evaluation_domains = { path = "../../evaluation_domains" }


### PR DESCRIPTION
This PR splits out the evaluation domains and splits out SRS generation for the dlog based proof.