### PR TITLE
optimize commitment opening a bit, add sg to opening proofs

### DIFF
--- a/dlog/commitment/Cargo.toml
+++ b/dlog/commitment/Cargo.toml
@@ -15,3 +15,4 @@ colored = "1.9.2"
 rand = "0.7.3"
 rayon = { version = "1" }
 blake2 = "0.7"
+itertools = "0.8.2"

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -16,10 +16,12 @@ use algebra::{
     UniformRand, VariableBaseMSM,
 };
 use ff_fft::DensePolynomial;
+use itertools::Itertools;
 use oracle::rndoracle::{ArithmeticSpongeParams, ProofError};
 use oracle::FqSponge;
 use rand_core::RngCore;
 use rayon::prelude::*;
+use std::iter::Iterator;
 
 type Fr<G> = <G as AffineCurve>::ScalarField;
 type Fq<G> = <G as AffineCurve>::BaseField;
@@ -30,9 +32,10 @@ pub struct OpeningProof<G: AffineCurve> {
     pub delta: G,
     pub z1: G::ScalarField,
     pub z2: G::ScalarField,
+    pub sg: G,
 }
 
-fn product<F: Field>(xs: impl Iterator<Item = F>) -> F {
+pub fn product<F: Field>(xs: impl Iterator<Item = F>) -> F {
     let mut res = F::one();
     for x in xs {
         res *= &x;
@@ -40,7 +43,7 @@ fn product<F: Field>(xs: impl Iterator<Item = F>) -> F {
     res
 }
 
-fn b_poly<F: Field>(chals: &Vec<F>, chal_invs: &Vec<F>, x: F) -> F {
+pub fn b_poly<F: Field>(chals: &Vec<F>, chal_invs: &Vec<F>, x: F) -> F {
     let k = chals.len();
 
     let mut pow_twos = vec![x];
@@ -50,6 +53,21 @@ fn b_poly<F: Field>(chals: &Vec<F>, chal_invs: &Vec<F>, x: F) -> F {
     }
 
     product((0..k).map(|i| (chal_invs[i] + &(chals[i] * &pow_twos[k - 1 - i]))))
+}
+
+pub fn b_poly_coefficients<F: Field>(s0: F, chal_squareds: &Vec<F>) -> Vec<F> {
+    let rounds = chal_squareds.len();
+    let s_length = 1 << rounds;
+    let mut s = vec![F::one(); s_length];
+    s[0] = s0;
+    let mut k: usize = 0;
+    let mut pow: usize = 1;
+    for i in 1..s_length {
+        k += if i == pow { 1 } else { 0 };
+        pow <<= if i == pow { 1 } else { 0 };
+        s[i] = s[i - (pow >> 1)] * &chal_squareds[rounds - 1 - (k - 1)];
+    }
+    s
 }
 
 fn ceil_log2(d: usize) -> usize {
@@ -95,7 +113,134 @@ fn squeeze_sqrt_challenge<Fq: Field, G, Fr: SquareRootField, EFqSponge: FqSponge
     squeeze_square_challenge(sponge).sqrt().unwrap()
 }
 
-fn shamir_sum<G: AffineCurve>(
+pub fn shamir_window_table<G: AffineCurve>(g1: G, g2: G) -> [G; 16] {
+    let g00_00 = G::prime_subgroup_generator().into_projective();
+    let g01_00 = g1.into_projective();
+    let g10_00 = {
+        let mut g = g01_00;
+        g.add_assign_mixed(&g1);
+        g
+    };
+    let g11_00 = {
+        let mut g = g10_00;
+        g.add_assign_mixed(&g1);
+        g
+    };
+
+    let g00_01 = g2.into_projective();
+    let g01_01 = {
+        let mut g = g00_01;
+        g.add_assign_mixed(&g1);
+        g
+    };
+    let g10_01 = {
+        let mut g = g01_01;
+        g.add_assign_mixed(&g1);
+        g
+    };
+    let g11_01 = {
+        let mut g = g10_01;
+        g.add_assign_mixed(&g1);
+        g
+    };
+
+    let g00_10 = {
+        let mut g = g00_01;
+        g.add_assign_mixed(&g2);
+        g
+    };
+    let g01_10 = {
+        let mut g = g00_10;
+        g.add_assign_mixed(&g1);
+        g
+    };
+    let g10_10 = {
+        let mut g = g01_10;
+        g.add_assign_mixed(&g1);
+        g
+    };
+    let g11_10 = {
+        let mut g = g10_10;
+        g.add_assign_mixed(&g1);
+        g
+    };
+    let g00_11 = {
+        let mut g = g00_10;
+        g.add_assign_mixed(&g2);
+        g
+    };
+    let g01_11 = {
+        let mut g = g00_11;
+        g.add_assign_mixed(&g1);
+        g
+    };
+    let g10_11 = {
+        let mut g = g01_11;
+        g.add_assign_mixed(&g1);
+        g
+    };
+    let g11_11 = {
+        let mut g = g10_11;
+        g.add_assign_mixed(&g1);
+        g
+    };
+
+    let mut v = vec![
+        g00_00, g01_00, g10_00, g11_00, g00_01, g01_01, g10_01, g11_01, g00_10, g01_10, g10_10,
+        g11_10, g00_11, g01_11, g10_11, g11_11,
+    ];
+    G::Projective::batch_normalization(v.as_mut_slice());
+    let v: Vec<_> = v.iter().map(|x| x.into_affine()).collect();
+    [
+        v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8], v[9], v[10], v[11], v[12], v[13],
+        v[14], v[15],
+    ]
+}
+
+pub fn window_shamir<G: AffineCurve>(
+    x1: G::ScalarField,
+    g1: G,
+    x2: G::ScalarField,
+    g2: G,
+) -> G::Projective {
+    let [_g00_00, g01_00, g10_00, g11_00, g00_01, g01_01, g10_01, g11_01, g00_10, g01_10, g10_10, g11_10, g00_11, g01_11, g10_11, g11_11] =
+        shamir_window_table(g1, g2);
+
+    let windows1 = BitIterator::new(x1.into_repr()).tuples();
+    let windows2 = BitIterator::new(x2.into_repr()).tuples();
+
+    let mut res = G::Projective::zero();
+
+    for ((hi_1, lo_1), (hi_2, lo_2)) in windows1.zip(windows2) {
+        res.double_in_place();
+        res.double_in_place();
+        match ((hi_1, lo_1), (hi_2, lo_2)) {
+            ((false, false), (false, false)) => (),
+            ((false, true), (false, false)) => res.add_assign_mixed(&g01_00),
+            ((true, false), (false, false)) => res.add_assign_mixed(&g10_00),
+            ((true, true), (false, false)) => res.add_assign_mixed(&g11_00),
+
+            ((false, false), (false, true)) => res.add_assign_mixed(&g00_01),
+            ((false, true), (false, true)) => res.add_assign_mixed(&g01_01),
+            ((true, false), (false, true)) => res.add_assign_mixed(&g10_01),
+            ((true, true), (false, true)) => res.add_assign_mixed(&g11_01),
+
+            ((false, false), (true, false)) => res.add_assign_mixed(&g00_10),
+            ((false, true), (true, false)) => res.add_assign_mixed(&g01_10),
+            ((true, false), (true, false)) => res.add_assign_mixed(&g10_10),
+            ((true, true), (true, false)) => res.add_assign_mixed(&g11_10),
+
+            ((false, false), (true, true)) => res.add_assign_mixed(&g00_11),
+            ((false, true), (true, true)) => res.add_assign_mixed(&g01_11),
+            ((true, false), (true, true)) => res.add_assign_mixed(&g10_11),
+            ((true, true), (true, true)) => res.add_assign_mixed(&g11_11),
+        }
+    }
+
+    res
+}
+
+pub fn shamir_sum<G: AffineCurve>(
     x1: G::ScalarField,
     g1: G,
     x2: G::ScalarField,
@@ -189,19 +334,13 @@ impl<G: AffineCurve> SRS<G> {
         rng: &mut dyn RngCore,
     ) -> Result<OpeningProof<G>, ProofError> {
         let u: G = G::prime_subgroup_generator(); // TODO: Should make this a random group element after the group map is implemented.
-        let rounds = ceil_log2(self.g.len());
 
         // scale the polynoms in accumulator shifted, if bounded, to the end of SRS
         // let mut p_comm = G::Projective::zero();
         let p = {
             let mut p = DensePolynomial::<Fr<G>>::zero();
             let mut scale = Fr::<G>::one();
-            for (p_i, degree_bound) in plnms.iter() {
-                // always mixing in the unshifted polynom
-                p += &(p_i.scale(scale));
-                // p_comm += &(comm_i.mul(scale));
-                scale *= &polyscale;
-
+            for (p_i, degree_bound) in plnms.iter().rev() {
                 match degree_bound {
                     Some(m) => {
                         // mixing in the shifted polynom since degree is bounded
@@ -211,9 +350,16 @@ impl<G: AffineCurve> SRS<G> {
                     }
                     _ => {}
                 }
+
+                // always mixing in the unshifted polynom
+                p += &(p_i.scale(scale));
+                // p_comm += &(comm_i.mul(scale));
+                scale *= &polyscale;
             }
             p
         };
+
+        let rounds = ceil_log2(self.g.len());
 
         // TODO: Add blindings to the commitments. Opening will require knowing the blinding factor
         // for each commitment in the batch.
@@ -287,7 +433,7 @@ impl<G: AffineCurve> SRS<G> {
             chal_invs.push(u_inv);
 
             a = a_hi
-                .iter()
+                .par_iter()
                 .zip(a_lo)
                 .map(|(&hi, &lo)| {
                     let mut res = hi * &u_inv;
@@ -297,7 +443,7 @@ impl<G: AffineCurve> SRS<G> {
                 .collect();
 
             b = b_lo
-                .iter()
+                .par_iter()
                 .zip(b_hi)
                 .map(|(&lo, &hi)| {
                     let mut res = lo * &u_inv;
@@ -312,7 +458,7 @@ impl<G: AffineCurve> SRS<G> {
                     let pairs: Vec<_> = g_lo.iter().zip(g_hi).collect();
                     pairs
                         .into_par_iter()
-                        .map(|(lo, hi)| shamir_sum::<G>(u_inv, *lo, u, hi))
+                        .map(|(lo, hi)| window_shamir::<G>(u_inv, *lo, u, hi))
                         .collect()
                 };
                 G::Projective::batch_normalization(g_proj.as_mut_slice());
@@ -344,7 +490,13 @@ impl<G: AffineCurve> SRS<G> {
         let z1 = a0 * &c + &d;
         let z2 = c * &r_prime + &r_delta;
 
-        Ok(OpeningProof { delta, lr, z1, z2 })
+        Ok(OpeningProof {
+            delta,
+            lr,
+            z1,
+            z2,
+            sg: g0,
+        })
     }
 
     // This function verifies batch of batched polynomial commitment opening proofs
@@ -389,6 +541,10 @@ impl<G: AffineCurve> SRS<G> {
         // - (r^i z1_i) G_i
         // - (r^i z2_i) H
         // - (r^i z1_i b_i) U_i
+
+        // We also check that the sg component of the proof is equal to the polynomial commitment
+        // to the "s" array
+
         let max_rounds = ceil_log2(self.g.len());
 
         let padded_length = 1 << max_rounds;
@@ -402,12 +558,12 @@ impl<G: AffineCurve> SRS<G> {
 
         // sample randomiser to scale the proofs with
         let rand_base = Fr::<G>::rand(rng);
+        let sg_rand_base = Fr::<G>::rand(rng);
+
         let mut rand_base_i = Fr::<G>::one();
+        let mut sg_rand_base_i = Fr::<G>::one();
 
         for (evaluation_points, xi, r, polys, opening) in batch.iter() {
-            let rounds = opening.lr.len();
-            let s_length = 1 << rounds;
-
             let u: G = G::prime_subgroup_generator(); // TODO: Should make this a random group element after the group map is implemented.
 
             let sponge = &mut EFqSponge::new(oracle_params.clone());
@@ -451,40 +607,31 @@ impl<G: AffineCurve> SRS<G> {
                 res
             };
 
-            let s = {
-                let mut s = vec![Fr::<G>::one(); s_length];
-                s[0] = chal_invs.iter().fold(Fr::<G>::one(), |x, y| x * &y);
-                let mut k: usize = 0;
-                let mut pow: usize = 1;
-                for i in 1..s_length {
-                    k += if i == pow { 1 } else { 0 };
-                    pow <<= if i == pow { 1 } else { 0 };
-                    s[i] = s[i - (pow >> 1)] * &chal_squareds[rounds - 1 - (k - 1)];
-                }
-                s
-            };
+            let s = b_poly_coefficients(
+                chal_invs.iter().fold(Fr::<G>::one(), |x, y| x * &y),
+                &chal_squareds,
+            );
 
             let neg_rand_base_i = -rand_base_i;
 
             // TERM
             // - rand_base_i z1 G
+            //
+            // we also add -sg_rand_base_i * G to check correctness of sg.
+            points.push(opening.sg);
+            scalars.push(neg_rand_base_i * &opening.z1 - &sg_rand_base_i);
+
+            // Here we add
+            // sg_rand_base_i * ( < s, self.g > )
             // =
-            // rand_base_i * ( - z1 * < s, self.g > )
-            // =
-            // - rand_base_i * (z1 * < s, self.g > )
+            // < sg_rand_base_i s, self.g >
+            //
+            // to check correctness of the sg component.
             {
-                let terms: Vec<_> = s
-                    .par_iter()
-                    .map(|s| {
-                        let mut term = opening.z1;
-                        term *= s;
-                        term *= &rand_base_i;
-                        term
-                    })
-                    .collect();
+                let terms: Vec<_> = s.par_iter().map(|s| sg_rand_base_i * s).collect();
 
                 for (i, term) in terms.iter().enumerate() {
-                    scalars[i] -= term;
+                    scalars[i] += term;
                 }
             }
 
@@ -523,16 +670,7 @@ impl<G: AffineCurve> SRS<G> {
                 let mut res = Fr::<G>::zero();
                 let mut xi_i = Fr::<G>::one();
 
-                for (comm, evals, shifted) in polys {
-                    let term = eval_polynomial(evals, *r);
-
-                    res += &(xi_i * &term);
-
-                    scalars.push(rand_base_i_c_i * &xi_i);
-                    points.push(*comm);
-
-                    xi_i *= xi;
-
+                for (comm, evals, shifted) in polys.iter().rev() {
                     match shifted {
                         Some((shifted_comm_i, m)) => {
                             // xi^i sum_j r^j elm_j^{N - m} f(elm_j)
@@ -551,6 +689,15 @@ impl<G: AffineCurve> SRS<G> {
                         }
                         None => (),
                     }
+
+                    let term = eval_polynomial(evals, *r);
+
+                    res += &(xi_i * &term);
+
+                    scalars.push(rand_base_i_c_i * &xi_i);
+                    points.push(*comm);
+
+                    xi_i *= xi;
                 }
                 res
             };
@@ -562,6 +709,7 @@ impl<G: AffineCurve> SRS<G> {
             points.push(opening.delta);
 
             rand_base_i *= &rand_base;
+            sg_rand_base_i *= &sg_rand_base;
         }
         // verify the equation
         let scalars: Vec<_> = scalars.iter().map(|x| x.into_repr()).collect();

--- a/dlog/tests/batch.rs
+++ b/dlog/tests/batch.rs
@@ -5,7 +5,7 @@ verification of a batch of batched opening proofs of polynomial commitments
 
 *****************************************************************************************************************/
 
-use algebra::{curves::bn_382::g::{Affine, Bn_382GParameters}, fields::bn_382::fp::Fp, UniformRand, AffineCurve};
+use algebra::{curves::bn_382::g::{Affine, Bn_382GParameters}, fields::bn_382::fp::Fp, UniformRand, AffineCurve, ProjectiveCurve};
 use commitment_dlog::{srs::SRS, commitment::OpeningProof};
 
 use oracle::marlin_sponge::{DefaultFqSponge};
@@ -17,6 +17,20 @@ use rand_core::OsRng;
 use rand::Rng;
 
 type Fr = <Affine as AffineCurve>::ScalarField;
+
+#[test]
+fn shamir_equivalence()
+{
+    let rng = &mut OsRng;
+
+    let g1 : Affine = (Affine::prime_subgroup_generator().into_projective() * &Fr::rand(rng)).into_affine();
+    let g2 : Affine = (Affine::prime_subgroup_generator().into_projective() * &Fr::rand(rng)).into_affine();
+
+    let x1 = Fr::rand(rng);
+    let x2 = Fr::rand(rng);
+
+    assert_eq!(commitment_dlog::commitment::shamir_sum(x1, g1, x2, g2), commitment_dlog::commitment::window_shamir(x1, g1, x2, g2))
+}
 
 #[test]
 fn batch_commitment_test()


### PR DESCRIPTION
This PR

1. Optimizes the computation of the "g" array in the bulletproofs opening.
2. Adds the "sg" polynomial to opening proofs so that we don't have to recompute them individually.