### PR TITLE
Modified scalar challenge

### DIFF
--- a/dlog/protocol/src/marlin_sponge.rs
+++ b/dlog/protocol/src/marlin_sponge.rs
@@ -3,12 +3,12 @@ use algebra::{
     Field, PrimeField,
 };
 use oracle::poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge};
-use oracle::marlin_sponge::{DefaultFrSponge};
+use oracle::marlin_sponge::{DefaultFrSponge, ScalarChallenge};
 
 pub trait FrSponge<Fr: Field> {
     fn new(p: ArithmeticSpongeParams<Fr>) -> Self;
     fn absorb(&mut self, x: &Fr);
-    fn challenge(&mut self) -> Fr;
+    fn challenge(&mut self) -> ScalarChallenge<Fr>;
     fn absorb_evaluations(&mut self, x_hat_beta1: &[Fr], e: &ProofEvaluations<Fr>);
 }
 
@@ -26,8 +26,8 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr> {
         self.sponge.absorb(&self.params, &[*x]);
     }
 
-    fn challenge(&mut self) -> Fr {
-        self.squeeze(oracle::marlin_sponge::CHALLENGE_LENGTH_IN_LIMBS)
+    fn challenge(&mut self) -> ScalarChallenge<Fr> {
+        ScalarChallenge(self.squeeze(oracle::marlin_sponge::CHALLENGE_LENGTH_IN_LIMBS))
     }
 
     fn absorb_evaluations(&mut self, x_hat: &[Fr], e: &ProofEvaluations<Fr>) {

--- a/dlog/protocol/src/prover.rs
+++ b/dlog/protocol/src/prover.rs
@@ -5,7 +5,7 @@ This source file implements prover's zk-proof primitive.
 *********************************************************************************************/
 
 use algebra::{Field, AffineCurve};
-use oracle::{FqSponge, rndoracle::{ProofError}};
+use oracle::{marlin_sponge::ScalarChallenge, FqSponge, rndoracle::{ProofError}};
 use ff_fft::{DensePolynomial, Evaluations};
 use commitment_dlog::commitment::{CommitmentCurve, Utils, PolyComm, OpeningProof, b_poly_coefficients, product};
 use circuits_dlog::index::Index;
@@ -185,7 +185,7 @@ impl<G: CommitmentCurve> ProverProof<G>
         fq_sponge.absorb_g(&g1_comm.unshifted);
         fq_sponge.absorb_g(&h1_comm.unshifted);
         // sample beta[0] oracle
-        oracles.beta[0] = fq_sponge.challenge();
+        oracles.beta[0] = ScalarChallenge(fq_sponge.challenge());
 
         // compute second sumcheck argument polynomials
         // --------------------------------------------------------------------
@@ -201,7 +201,7 @@ impl<G: CommitmentCurve> ProverProof<G>
         fq_sponge.absorb_g(&g2_comm.unshifted);
         fq_sponge.absorb_g(&h2_comm.unshifted);
         // sample beta[1] oracle
-        oracles.beta[1] = fq_sponge.challenge();
+        oracles.beta[1] = ScalarChallenge(fq_sponge.challenge());
 
         // compute third sumcheck argument polynomials
         // --------------------------------------------------------------------
@@ -217,7 +217,7 @@ impl<G: CommitmentCurve> ProverProof<G>
         fq_sponge.absorb_g(&g3_comm.unshifted);
         fq_sponge.absorb_g(&h3_comm.unshifted);
         // sample beta[2] & batch oracles
-        oracles.beta[2] = fq_sponge.challenge();
+        oracles.beta[2] = ScalarChallenge(fq_sponge.challenge());
 
         let fq_sponge_before_evaluations = fq_sponge.clone();
 
@@ -236,38 +236,38 @@ impl<G: CommitmentCurve> ProverProof<G>
             (
                 |i| ProofEvaluations
                 {
-                    w  : w.eval(oracles.beta[i], index.max_poly_size),
-                    za : za.eval(oracles.beta[i], index.max_poly_size),
-                    zb : zb.eval(oracles.beta[i], index.max_poly_size),
-                    h1 : h1.eval(oracles.beta[i], index.max_poly_size),
-                    g1 : g1.eval(oracles.beta[i], index.max_poly_size),
-                    h2 : h2.eval(oracles.beta[i], index.max_poly_size),
-                    g2 : g2.eval(oracles.beta[i], index.max_poly_size),
-                    h3 : h3.eval(oracles.beta[i], index.max_poly_size),
-                    g3 : g3.eval(oracles.beta[i], index.max_poly_size),
+                    w  : w.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                    za : za.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                    zb : zb.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                    h1 : h1.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                    g1 : g1.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                    h2 : h2.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                    g2 : g2.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                    h3 : h3.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                    g3 : g3.eval(oracles.beta[i].to_field(), index.max_poly_size),
                     row:
                     [
-                        index.compiled[0].row.eval(oracles.beta[i], index.max_poly_size),
-                        index.compiled[1].row.eval(oracles.beta[i], index.max_poly_size),
-                        index.compiled[2].row.eval(oracles.beta[i], index.max_poly_size),
+                        index.compiled[0].row.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                        index.compiled[1].row.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                        index.compiled[2].row.eval(oracles.beta[i].to_field(), index.max_poly_size),
                     ],
                     col:
                     [
-                        index.compiled[0].col.eval(oracles.beta[i], index.max_poly_size),
-                        index.compiled[1].col.eval(oracles.beta[i], index.max_poly_size),
-                        index.compiled[2].col.eval(oracles.beta[i], index.max_poly_size),
+                        index.compiled[0].col.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                        index.compiled[1].col.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                        index.compiled[2].col.eval(oracles.beta[i].to_field(), index.max_poly_size),
                     ],
                     val:
                     [
-                        index.compiled[0].val.eval(oracles.beta[i], index.max_poly_size),
-                        index.compiled[1].val.eval(oracles.beta[i], index.max_poly_size),
-                        index.compiled[2].val.eval(oracles.beta[i], index.max_poly_size),
+                        index.compiled[0].val.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                        index.compiled[1].val.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                        index.compiled[2].val.eval(oracles.beta[i].to_field(), index.max_poly_size),
                     ],
                     rc:
                     [
-                        index.compiled[0].rc.eval(oracles.beta[i], index.max_poly_size),
-                        index.compiled[1].rc.eval(oracles.beta[i], index.max_poly_size),
-                        index.compiled[2].rc.eval(oracles.beta[i], index.max_poly_size),
+                        index.compiled[0].rc.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                        index.compiled[1].rc.eval(oracles.beta[i].to_field(), index.max_poly_size),
+                        index.compiled[2].rc.eval(oracles.beta[i].to_field(), index.max_poly_size),
                     ],
                 }
             ).collect::<Vec<_>>();
@@ -275,9 +275,9 @@ impl<G: CommitmentCurve> ProverProof<G>
         };
 
         let x_hat_evals =
-            [ x_hat.eval(oracles.beta[0], index.max_poly_size)
-            , x_hat.eval(oracles.beta[1], index.max_poly_size)
-            , x_hat.eval(oracles.beta[2], index.max_poly_size) ];
+            [ x_hat.eval(oracles.beta[0].to_field(), index.max_poly_size)
+            , x_hat.eval(oracles.beta[1].to_field(), index.max_poly_size)
+            , x_hat.eval(oracles.beta[2].to_field(), index.max_poly_size) ];
 
         oracles.x_hat = x_hat_evals.clone();
 
@@ -343,9 +343,9 @@ impl<G: CommitmentCurve> ProverProof<G>
             (
                 group_map,
                 polynoms,
-                &oracles.beta.to_vec(),
-                oracles.polys,
-                oracles.evals,
+                &oracles.beta.iter().map(|x| x.to_field()).collect(),
+                oracles.polys.to_field(),
+                oracles.evals.to_field(),
                 fq_sponge_before_evaluations,
                 rng
             ), 
@@ -411,7 +411,7 @@ impl<G: CommitmentCurve> ProverProof<G>
     ) -> Result<(DensePolynomial<Fr<G>>, DensePolynomial<Fr<G>>), ProofError>
     {
         // precompute Lagrange polynomial evaluations
-        let lagrng = index.domains.h.evaluate_all_lagrange_coefficients(oracles.beta[0]);
+        let lagrng = index.domains.h.evaluate_all_lagrange_coefficients(oracles.beta[0].to_field());
 
         // compute and return H2 & G2 polynomials
         // use the precomputed normalized Lagrange evaluations for interpolation evaluations
@@ -444,8 +444,11 @@ impl<G: CommitmentCurve> ProverProof<G>
         oracles: &RandomOracles<Fr<G>>
     ) -> Result<(DensePolynomial<Fr<G>>, DensePolynomial<Fr<G>>), ProofError>
     {
-        let vanish = index.domains.h.evaluate_vanishing_polynomial(oracles.beta[0]) *
-            &index.domains.h.evaluate_vanishing_polynomial(oracles.beta[1]);
+        let beta0 = oracles.beta[0].to_field();
+        let beta1 = oracles.beta[1].to_field();
+
+        let vanish = index.domains.h.evaluate_vanishing_polynomial(beta0) *
+            &index.domains.h.evaluate_vanishing_polynomial(beta1);
 
         // compute polynomial f3
         let f3 = (0..3).map
@@ -459,8 +462,8 @@ impl<G: CommitmentCurve> ProverProof<G>
                         (
                             |j|
                             {
-                                (oracles.beta[0] - &index.compiled[i].col_eval_k[j]) *
-                                &(oracles.beta[1] - &index.compiled[i].row_eval_k[j])
+                                (beta0 - &index.compiled[i].col_eval_k[j]) *
+                                &(beta1 - &index.compiled[i].row_eval_k[j])
                             }
                         ).collect();
                         algebra::fields::batch_inversion::<Fr<G>>(&mut fractions);
@@ -485,7 +488,7 @@ impl<G: CommitmentCurve> ProverProof<G>
 
         // precompute polynomials (row(X)-oracle1)*(col(X)-oracle2) in evaluation form over domains.b
         let crb: Vec<Vec<Fr<G>>> =
-            (0..3).map(|i| index.compiled[i].compute_row_2_col_1(oracles.beta[0], oracles.beta[1])).collect();
+            (0..3).map(|i| index.compiled[i].compute_row_2_col_1(beta0, beta1)).collect();
 
         // compute polynomial a
         let a = (0..3).map
@@ -537,9 +540,9 @@ pub struct RandomOracles<F: Field>
     pub eta_a: F,
     pub eta_b: F,
     pub eta_c: F,
-    pub polys: F,
-    pub evals: F,
-    pub beta: [F; 3],
+    pub polys: ScalarChallenge<F>,
+    pub evals: ScalarChallenge<F>,
+    pub beta: [ScalarChallenge<F>; 3],
 
     pub digest_before_evaluations: F,
     pub x_hat: [Vec<F>; 3],
@@ -549,15 +552,16 @@ impl<F: Field> RandomOracles<F>
 {
     pub fn zero () -> Self
     {
+        let c = ScalarChallenge(F::zero());
         Self
         {
             alpha: F::zero(),
             eta_a: F::zero(),
             eta_b: F::zero(),
             eta_c: F::zero(),
-            polys: F::zero(),
-            evals: F::zero(),
-            beta: [F::zero(), F::zero(), F::zero()],
+            polys: c,
+            evals: c,
+            beta: [c, c, c],
             x_hat: [Vec::new(), Vec::new(), Vec::new()],
             digest_before_evaluations: F::zero(),
         }

--- a/dlog/protocol/src/verifier.rs
+++ b/dlog/protocol/src/verifier.rs
@@ -48,7 +48,8 @@ impl<G: CommitmentCurve> ProverProof<G>
         x_hat_value: Fr<G>
     ) -> bool
     {
-        let beta0 = oracles.beta[0].to_field();
+        let endo = &index.srs.get_ref().endo_r;
+        let beta0 = oracles.beta[0].to_field(endo);
         // compute ra*zm - ram*z ?= h*v + b*g to verify the first sumcheck argument
         (oracles.alpha.pow([index.domains.h.size]) - &beta0.pow([index.domains.h.size])) *
             &(0..3).map
@@ -87,7 +88,8 @@ impl<G: CommitmentCurve> ProverProof<G>
         evals: &ProofEvals<Fr<G>>,
     ) -> bool
     {
-        let beta1 = oracles.beta[1].to_field();
+        let endo = &index.srs.get_ref().endo_r;
+        let beta1 = oracles.beta[1].to_field(endo);
         self.sigma3 * &index.domains.k.size_as_field_element *
             &((oracles.alpha.pow([index.domains.h.size]) - &beta1.pow([index.domains.h.size])))
         ==
@@ -108,9 +110,10 @@ impl<G: CommitmentCurve> ProverProof<G>
         evals: &ProofEvals<Fr<G>>,
     ) -> bool
     {
-        let beta0 = oracles.beta[0].to_field();
-        let beta1 = oracles.beta[1].to_field();
-        let beta2 = oracles.beta[2].to_field();
+        let endo = &index.srs.get_ref().endo_r;
+        let beta0 = oracles.beta[0].to_field(endo);
+        let beta1 = oracles.beta[1].to_field(endo);
+        let beta2 = oracles.beta[2].to_field(endo);
 
         let crb: Vec<Fr<G>> = (0..3).map
         (
@@ -157,6 +160,7 @@ impl<G: CommitmentCurve> ProverProof<G>
         rng: &mut dyn RngCore
     ) -> bool
     {
+        let endo = &index.srs.get_ref().endo_r;
         let params = proofs.iter().map
         (
             |proof|
@@ -170,9 +174,9 @@ impl<G: CommitmentCurve> ProverProof<G>
 
                 let beta =
                 [
-                    oracles.beta[0].to_field().pow([index.max_poly_size as u64]),
-                    oracles.beta[1].to_field().pow([index.max_poly_size as u64]),
-                    oracles.beta[2].to_field().pow([index.max_poly_size as u64])
+                    oracles.beta[0].to_field(endo).pow([index.max_poly_size as u64]),
+                    oracles.beta[1].to_field(endo).pow([index.max_poly_size as u64]),
+                    oracles.beta[2].to_field(endo).pow([index.max_poly_size as u64])
                 ];
 
                 let polys = proof.prev_challenges.iter().map(|(chals, poly)| {
@@ -192,12 +196,12 @@ impl<G: CommitmentCurve> ProverProof<G>
                     (
                         |i|
                         {
-                            let full = b_poly(&chals, &chal_invs, oracles.beta[i].to_field());
+                            let full = b_poly(&chals, &chal_invs, oracles.beta[i].to_field(endo));
                             if index.max_poly_size == b.len() {return vec![full]}
                             let mut betaacc = Fr::<G>::one();
                             let diff = (index.max_poly_size..b.len()).map
                             (
-                                |j| {let ret = betaacc * &b[j]; betaacc *= &oracles.beta[i].to_field(); ret}
+                                |j| {let ret = betaacc * &b[j]; betaacc *= &oracles.beta[i].to_field(endo); ret}
                             ).fold(Fr::<G>::zero(), |x, y| x + &y);
                             vec![full - &(diff * &beta[i]), diff]
                         }
@@ -305,9 +309,9 @@ impl<G: CommitmentCurve> ProverProof<G>
 
                 Ok((
                     fq_sponge.clone(),
-                    oracles.beta.iter().map(|x| x.to_field()).collect(),
-                    oracles.polys.to_field(),
-                    oracles.evals.to_field(),
+                    oracles.beta.iter().map(|x| x.to_field(endo)).collect(),
+                    oracles.polys.to_field(endo),
+                    oracles.evals.to_field(endo),
                     polynoms,
                     &proof.proof
                 ))
@@ -373,10 +377,12 @@ impl<G: CommitmentCurve> ProverProof<G>
             s
         };
 
+        let endo = &index.srs.get_ref().endo_r;
+
         let x_hat_evals =
-            [ x_hat.eval(oracles.beta[0].to_field(), index.max_poly_size)
-            , x_hat.eval(oracles.beta[1].to_field(), index.max_poly_size)
-            , x_hat.eval(oracles.beta[2].to_field(), index.max_poly_size) ];
+            [ x_hat.eval(oracles.beta[0].to_field(endo), index.max_poly_size)
+            , x_hat.eval(oracles.beta[1].to_field(endo), index.max_poly_size)
+            , x_hat.eval(oracles.beta[2].to_field(endo), index.max_poly_size) ];
 
         oracles.x_hat = x_hat_evals.clone();
 

--- a/oracle/src/marlin_sponge.rs
+++ b/oracle/src/marlin_sponge.rs
@@ -11,6 +11,20 @@ pub const CHALLENGE_LENGTH_IN_LIMBS: usize = 2;
 
 const HIGH_ENTROPY_LIMBS: usize = 4;
 
+// A challenge which is used as a scalar on a group element in the verifier
+#[derive(Clone, Copy, Debug)]
+pub struct ScalarChallenge<F>(pub F);
+
+impl<F : Field> ScalarChallenge<F> {
+    pub fn to_field(&self) -> F {
+        let ScalarChallenge(x) = self;
+        let length_in_bits : u64 = (64 * CHALLENGE_LENGTH_IN_LIMBS) as u64;
+        let two : F = (2 as u64).into();
+        let t = two.pow(&[length_in_bits - 1]);
+        t + x
+    }
+}
+
 #[derive(Clone)]
 pub struct DefaultFqSponge<P: SWModelParameters> {
     pub params: ArithmeticSpongeParams<P::BaseField>,

--- a/oracle/src/marlin_sponge.rs
+++ b/oracle/src/marlin_sponge.rs
@@ -42,7 +42,7 @@ impl<F : PrimeField> ScalarChallenge<F> {
         let one = F::one();
         let neg_one = -one;
 
-        for i in (length_in_bits/2 - 1)..0 {
+        for i in (0..(length_in_bits/2)).rev() {
             a.double_in_place();
             b.double_in_place();
 

--- a/pairing/circuits/src/index.rs
+++ b/pairing/circuits/src/index.rs
@@ -8,12 +8,31 @@ use sprs::CsMat;
 use std::collections::HashMap;
 use rand_core::RngCore;
 use commitment_pairing::urs::URS;
-use algebra::PairingEngine;
+use algebra::{AffineCurve, PairingEngine, curves::models::short_weierstrass_jacobian::{GroupAffine as SWJAffine}};
 use oracle::rndoracle::ProofError;
 use oracle::poseidon::ArithmeticSpongeParams;
 pub use super::compiled::Compiled;
 pub use super::gate::CircuitGate;
 use evaluation_domains::EvaluationDomains;
+
+pub trait CoordinatesCurve: AffineCurve {
+    fn to_coordinates(&self) -> Option<(Self::BaseField, Self::BaseField)>;
+    fn of_coordinates(x:Self::BaseField, y:Self::BaseField) -> Self;
+}
+
+impl<P: algebra::SWModelParameters> CoordinatesCurve for SWJAffine<P> {
+    fn to_coordinates(&self) -> Option<(Self::BaseField, Self::BaseField)>{
+        if self.infinity {
+            None
+        } else {
+            Some((self.x, self.y))
+        }
+    }
+
+    fn of_coordinates(x:Self::BaseField, y:Self::BaseField) -> Self {
+        SWJAffine::<P>::new(x, y, false)
+    }
+}
 
 pub enum URSValue<'a, E : PairingEngine> {
     Value(URS<E>),
@@ -76,6 +95,10 @@ pub struct Index<'a, E: PairingEngine>
     // random oracle argument parameters
     pub fr_sponge_params: ArithmeticSpongeParams<E::Fr>,
     pub fq_sponge_params: ArithmeticSpongeParams<E::Fq>,
+
+    // Coefficients for the curve endomorphism
+    pub endo_r: E::Fr,
+    pub endo_q: E::Fq,
 }
 
 pub struct MatrixValues<A> {
@@ -105,6 +128,79 @@ pub struct VerifierIndex<E: PairingEngine>
     // random oracle argument parameters
     pub fr_sponge_params: ArithmeticSpongeParams<E::Fr>,
     pub fq_sponge_params: ArithmeticSpongeParams<E::Fq>,
+
+    // Coefficients for the curve endomorphism
+    pub endo_r: E::Fr,
+    pub endo_q: E::Fq,
+}
+
+impl<'a, E: PairingEngine> Index<'a, E>
+where E::G1Affine: CoordinatesCurve
+{
+    // this function compiles the circuit from constraints
+    pub fn create<'b>
+    (
+        a: CsMat<E::Fr>,
+        b: CsMat<E::Fr>,
+        c: CsMat<E::Fr>,
+        public_inputs: usize,
+        fr_sponge_params: ArithmeticSpongeParams<E::Fr>,
+        fq_sponge_params: ArithmeticSpongeParams<E::Fq>,
+        urs : URSSpec<'a, 'b, E>
+    ) -> Result<Self, ProofError>
+    {
+        if a.shape() != b.shape() ||
+            a.shape() != c.shape() ||
+            a.shape().0 != a.shape().1 ||
+            public_inputs == a.shape().0 ||
+            public_inputs == 0
+        {
+            return Err(ProofError::ConstraintInconsist)
+        }
+
+        let nonzero_entries : usize =
+            [&a, &b, &c].iter().map(|x| x.nnz()).max()
+            .map_or(Err(ProofError::RuntimeEnv), |s| Ok(s))?;
+
+        let domains = EvaluationDomains::create(
+            a.shape().0,
+            public_inputs,
+            nonzero_entries)
+            .map_or(Err(ProofError::EvaluationGroup), |s| Ok(s))?;
+
+        let urs = URSValue::create(domains, urs);
+
+        let endo_q : E::Fq = oracle::marlin_sponge::endo_coefficient();
+        let endo_r = {
+            let potential_endo_r : E::Fr = oracle::marlin_sponge::endo_coefficient();
+            let t = E::G1Affine::prime_subgroup_generator();
+            let (x, y) = t.to_coordinates().unwrap();
+            let phi_t = E::G1Affine::of_coordinates(x * &endo_q, y);
+            if t.mul(potential_endo_r) == phi_t.into() {
+                potential_endo_r
+            } else {
+                potential_endo_r * &potential_endo_r
+            }
+        };
+
+        Ok(Index::<E>
+        {
+            compiled:
+            [
+                Compiled::<E>::compile(urs.get_ref(), domains.h, domains.k, domains.b, a)?,
+                Compiled::<E>::compile(urs.get_ref(), domains.h, domains.k, domains.b, b)?,
+                Compiled::<E>::compile(urs.get_ref(), domains.h, domains.k, domains.b, c)?,
+            ],
+            fr_sponge_params,
+            fq_sponge_params,
+            public_inputs,
+            domains,
+            urs,
+            endo_q,
+            endo_r
+        })
+    }
+
 }
 
 impl<'a, E: PairingEngine> Index<'a, E>
@@ -150,57 +246,10 @@ impl<'a, E: PairingEngine> Index<'a, E>
             public_inputs: self.public_inputs,
             fr_sponge_params: self.fr_sponge_params.clone(),
             fq_sponge_params: self.fq_sponge_params.clone(),
-            urs
+            urs,
+            endo_q: self.endo_q,
+            endo_r: self.endo_r,
         }
-    }
-
-    // this function compiles the circuit from constraints
-    pub fn create<'b>
-    (
-        a: CsMat<E::Fr>,
-        b: CsMat<E::Fr>,
-        c: CsMat<E::Fr>,
-        public_inputs: usize,
-        fr_sponge_params: ArithmeticSpongeParams<E::Fr>,
-        fq_sponge_params: ArithmeticSpongeParams<E::Fq>,
-        urs : URSSpec<'a, 'b, E>
-    ) -> Result<Self, ProofError>
-    {
-        if a.shape() != b.shape() ||
-            a.shape() != c.shape() ||
-            a.shape().0 != a.shape().1 ||
-            public_inputs == a.shape().0 ||
-            public_inputs == 0
-        {
-            return Err(ProofError::ConstraintInconsist)
-        }
-
-        let nonzero_entries : usize =
-            [&a, &b, &c].iter().map(|x| x.nnz()).max()
-            .map_or(Err(ProofError::RuntimeEnv), |s| Ok(s))?;
-
-        let domains = EvaluationDomains::create(
-            a.shape().0,
-            public_inputs,
-            nonzero_entries)
-            .map_or(Err(ProofError::EvaluationGroup), |s| Ok(s))?;
-
-        let urs = URSValue::create(domains, urs);
-
-        Ok(Index::<E>
-        {
-            compiled:
-            [
-                Compiled::<E>::compile(urs.get_ref(), domains.h, domains.k, domains.b, a)?,
-                Compiled::<E>::compile(urs.get_ref(), domains.h, domains.k, domains.b, b)?,
-                Compiled::<E>::compile(urs.get_ref(), domains.h, domains.k, domains.b, c)?,
-            ],
-            fr_sponge_params,
-            fq_sponge_params,
-            public_inputs,
-            domains,
-            urs
-        })
     }
 
     // This function verifies the consistency of the wire assignements (witness) against the constraints

--- a/pairing/protocol/src/marlin_sponge.rs
+++ b/pairing/protocol/src/marlin_sponge.rs
@@ -3,12 +3,12 @@ use algebra::{
     Field, PairingEngine, PrimeField,
 };
 
-use oracle::{marlin_sponge::{DefaultFrSponge, FqSponge}, poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge}};
+use oracle::{marlin_sponge::{DefaultFrSponge, FqSponge, ScalarChallenge}, poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge}};
 
 pub trait FrSponge<Fr: Field> {
     fn new(p: ArithmeticSpongeParams<Fr>) -> Self;
     fn absorb(&mut self, x: &Fr);
-    fn challenge(&mut self) -> Fr;
+    fn challenge(&mut self) -> ScalarChallenge<Fr>;
     fn absorb_evaluations(&mut self, x_hat: &Fr, e: &ProofEvaluations<Fr>);
 }
 
@@ -31,8 +31,8 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr> {
         self.sponge.absorb(&self.params, &[*x]);
     }
 
-    fn challenge(&mut self) -> Fr {
-        self.squeeze(oracle::marlin_sponge::CHALLENGE_LENGTH_IN_LIMBS)
+    fn challenge(&mut self) -> ScalarChallenge<Fr> {
+        ScalarChallenge(self.squeeze(oracle::marlin_sponge::CHALLENGE_LENGTH_IN_LIMBS))
     }
 
     fn absorb_evaluations(&mut self, x_hat: &Fr, e: &ProofEvaluations<Fr>) {

--- a/pairing/protocol/src/prover.rs
+++ b/pairing/protocol/src/prover.rs
@@ -9,7 +9,7 @@ use oracle::rndoracle::{ProofError};
 use ff_fft::{DensePolynomial, Evaluations};
 use commitment_pairing::commitment::Utils;
 use circuits_pairing::index::Index;
-use oracle::marlin_sponge::{FqSponge};
+use oracle::marlin_sponge::{FqSponge, ScalarChallenge};
 use crate::marlin_sponge::{FrSponge};
 
 #[derive(Clone)]
@@ -173,7 +173,7 @@ impl<E: PairingEngine> ProverProof<E>
         // absorb H1, G1 polycommitments
         fq_sponge.absorb_g(&[g1_comm.0, g1_comm.1, h1_comm]);
         // sample beta[0] oracle
-        oracles.beta[0] = fq_sponge.challenge();
+        oracles.beta[0] = ScalarChallenge(fq_sponge.challenge());
 
         // compute second sumcheck argument polynomials
         // --------------------------------------------------------------------
@@ -188,7 +188,7 @@ impl<E: PairingEngine> ProverProof<E>
         fq_sponge.absorb_fr(&sigma2);
         fq_sponge.absorb_g(&[g2_comm.0, g2_comm.1, h2_comm]);
         // sample beta[1] oracle
-        oracles.beta[1] = fq_sponge.challenge();
+        oracles.beta[1] = ScalarChallenge(fq_sponge.challenge());
 
         // compute third sumcheck argument polynomials
         // --------------------------------------------------------------------
@@ -203,10 +203,10 @@ impl<E: PairingEngine> ProverProof<E>
         fq_sponge.absorb_fr(&sigma3);
         fq_sponge.absorb_g(&[g3_comm.0, g3_comm.1, h3_comm]);
         // sample beta[2] & batch oracles
-        oracles.beta[2] = fq_sponge.challenge();
-        oracles.r_k = fq_sponge.challenge();
+        oracles.beta[2] = ScalarChallenge(fq_sponge.challenge());
+        oracles.r_k = ScalarChallenge(fq_sponge.challenge());
 
-        let digest_before_evaluations =fq_sponge.digest();
+        let digest_before_evaluations = fq_sponge.digest();
         oracles.digest_before_evaluations = digest_before_evaluations;
 
         let mut fr_sponge = {
@@ -216,42 +216,42 @@ impl<E: PairingEngine> ProverProof<E>
         };
 
         let evals = ProofEvaluations {
-            w  : w.evaluate(oracles.beta[0]),
-            za : za.evaluate(oracles.beta[0]),
-            zb : zb.evaluate(oracles.beta[0]),
-            h1 : h1.evaluate(oracles.beta[0]),
-            g1 : g1.evaluate(oracles.beta[0]),
-            h2 : h2.evaluate(oracles.beta[1]),
-            g2 : g2.evaluate(oracles.beta[1]),
-            h3 : h3.evaluate(oracles.beta[2]),
-            g3 : g3.evaluate(oracles.beta[2]),
+            w  : w.evaluate(oracles.beta[0].to_field()),
+            za : za.evaluate(oracles.beta[0].to_field()),
+            zb : zb.evaluate(oracles.beta[0].to_field()),
+            h1 : h1.evaluate(oracles.beta[0].to_field()),
+            g1 : g1.evaluate(oracles.beta[0].to_field()),
+            h2 : h2.evaluate(oracles.beta[1].to_field()),
+            g2 : g2.evaluate(oracles.beta[1].to_field()),
+            h3 : h3.evaluate(oracles.beta[2].to_field()),
+            g3 : g3.evaluate(oracles.beta[2].to_field()),
             row:
             [
-                index.compiled[0].row.evaluate(oracles.beta[2]),
-                index.compiled[1].row.evaluate(oracles.beta[2]),
-                index.compiled[2].row.evaluate(oracles.beta[2]),
+                index.compiled[0].row.evaluate(oracles.beta[2].to_field()),
+                index.compiled[1].row.evaluate(oracles.beta[2].to_field()),
+                index.compiled[2].row.evaluate(oracles.beta[2].to_field()),
             ],
             col:
             [
-                index.compiled[0].col.evaluate(oracles.beta[2]),
-                index.compiled[1].col.evaluate(oracles.beta[2]),
-                index.compiled[2].col.evaluate(oracles.beta[2]),
+                index.compiled[0].col.evaluate(oracles.beta[2].to_field()),
+                index.compiled[1].col.evaluate(oracles.beta[2].to_field()),
+                index.compiled[2].col.evaluate(oracles.beta[2].to_field()),
             ],
             val:
             [
-                index.compiled[0].val.evaluate(oracles.beta[2]),
-                index.compiled[1].val.evaluate(oracles.beta[2]),
-                index.compiled[2].val.evaluate(oracles.beta[2]),
+                index.compiled[0].val.evaluate(oracles.beta[2].to_field()),
+                index.compiled[1].val.evaluate(oracles.beta[2].to_field()),
+                index.compiled[2].val.evaluate(oracles.beta[2].to_field()),
             ],
             rc:
             [
-                index.compiled[0].rc.evaluate(oracles.beta[2]),
-                index.compiled[1].rc.evaluate(oracles.beta[2]),
-                index.compiled[2].rc.evaluate(oracles.beta[2]),
+                index.compiled[0].rc.evaluate(oracles.beta[2].to_field()),
+                index.compiled[1].rc.evaluate(oracles.beta[2].to_field()),
+                index.compiled[2].rc.evaluate(oracles.beta[2].to_field()),
             ],
         };
 
-        let x_hat_beta1 = x_hat.evaluate(oracles.beta[0]);
+        let x_hat_beta1 = x_hat.evaluate(oracles.beta[0].to_field());
         oracles.x_hat_beta1 = x_hat_beta1;
 
         fr_sponge.absorb_evaluations(&x_hat_beta1, &evals);
@@ -261,6 +261,8 @@ impl<E: PairingEngine> ProverProof<E>
 
         // construct the proof
         // --------------------------------------------------------------------
+
+        let batch_chal = oracles.batch.to_field();
 
         Ok(ProverProof
         {
@@ -287,8 +289,8 @@ impl<E: PairingEngine> ProverProof<E>
                     &g1,
                     &h1,
                 ],
-                oracles.batch,
-                oracles.beta[0]
+                batch_chal,
+                oracles.beta[0].to_field()
             )?,
             proof2: urs.open
             (
@@ -297,8 +299,8 @@ impl<E: PairingEngine> ProverProof<E>
                     &g2,
                     &h2,
                 ],
-                oracles.batch,
-                oracles.beta[1]
+                batch_chal,
+                oracles.beta[1].to_field()
             )?,
             proof3: urs.open
             (
@@ -319,8 +321,8 @@ impl<E: PairingEngine> ProverProof<E>
                     &index.compiled[1].rc,
                     &index.compiled[2].rc,
                 ],
-                oracles.batch,
-                oracles.beta[2]
+                batch_chal,
+                oracles.beta[2].to_field()
             )?,
 
             // polynomial evaluations
@@ -383,7 +385,7 @@ impl<E: PairingEngine> ProverProof<E>
     ) -> Result<(DensePolynomial<E::Fr>, DensePolynomial<E::Fr>), ProofError>
     {
         // precompute Lagrange polynomial evaluations
-        let lagrng = index.domains.h.evaluate_all_lagrange_coefficients(oracles.beta[0]);
+        let lagrng = index.domains.h.evaluate_all_lagrange_coefficients(oracles.beta[0].to_field());
 
         // compute and return H2 & G2 polynomials
         // use the precomputed normalized Lagrange evaluations for interpolation evaluations
@@ -416,8 +418,8 @@ impl<E: PairingEngine> ProverProof<E>
         oracles: &RandomOracles<E::Fr>
     ) -> Result<(DensePolynomial<E::Fr>, DensePolynomial<E::Fr>), ProofError>
     {
-        let vanish = index.domains.h.evaluate_vanishing_polynomial(oracles.beta[0]) *
-            &index.domains.h.evaluate_vanishing_polynomial(oracles.beta[1]);
+        let vanish = index.domains.h.evaluate_vanishing_polynomial(oracles.beta[0].to_field()) *
+            &index.domains.h.evaluate_vanishing_polynomial(oracles.beta[1].to_field());
 
         // compute polynomial f3
         let f3 = (0..3).map
@@ -431,8 +433,8 @@ impl<E: PairingEngine> ProverProof<E>
                         (
                             |j|
                             {
-                                (oracles.beta[0] - &index.compiled[i].col_eval_k[j]) *
-                                &(oracles.beta[1] - &index.compiled[i].row_eval_k[j])
+                                (oracles.beta[0].to_field() - &index.compiled[i].col_eval_k[j]) *
+                                &(oracles.beta[1].to_field() - &index.compiled[i].row_eval_k[j])
                             }
                         ).collect();
                         algebra::fields::batch_inversion::<E::Fr>(&mut fractions);
@@ -457,7 +459,7 @@ impl<E: PairingEngine> ProverProof<E>
 
         // precompute polynomials (row(X)-oracle1)*(col(X)-oracle2) in evaluation form over domains.b
         let crb: Vec<Vec<E::Fr>> =
-            (0..3).map(|i| index.compiled[i].compute_row_2_col_1(oracles.beta[0], oracles.beta[1])).collect();
+            (0..3).map(|i| index.compiled[i].compute_row_2_col_1(oracles.beta[0].to_field(), oracles.beta[1].to_field())).collect();
 
         // compute polynomial a
         let a = (0..3).map
@@ -509,33 +511,34 @@ pub struct RandomOracles<F: Field>
     pub eta_a: F,
     pub eta_b: F,
     pub eta_c: F,
-    pub beta: [F; 3],
-    pub r_k : F,
+    pub beta: [ScalarChallenge<F>; 3],
+    pub r_k : ScalarChallenge<F>,
 
     pub x_hat_beta1: F,
     pub digest_before_evaluations: F,
 
     // Sampled using the other sponge
-    pub batch: F,
-    pub r: F,
+    pub batch: ScalarChallenge<F>,
+    pub r: ScalarChallenge<F>,
 }
 
 impl<F: Field> RandomOracles<F>
 {
     pub fn zero () -> Self
     {
+        let c = ScalarChallenge(F::zero());
         Self
         {
             alpha: F::zero(),
             eta_a: F::zero(),
             eta_b: F::zero(),
             eta_c: F::zero(),
-            batch: F::zero(),
-            beta: [F::zero(), F::zero(), F::zero()],
-            r: F::zero(),
+            batch: c,
+            beta: [c, c, c],
+            r: c,
             x_hat_beta1: F::zero(),
             digest_before_evaluations: F::zero(),
-            r_k: F::zero(),
+            r_k: c,
         }
     }
 }

--- a/pairing/protocol/src/verifier.rs
+++ b/pairing/protocol/src/verifier.rs
@@ -10,7 +10,7 @@ use oracle::rndoracle::{ProofError};
 pub use super::prover::{ProverProof, RandomOracles};
 use algebra::{Field, PairingEngine};
 use ff_fft::{DensePolynomial, Evaluations};
-use oracle::marlin_sponge::{FqSponge};
+use oracle::marlin_sponge::{FqSponge, ScalarChallenge};
 use crate::marlin_sponge::{FrSponge};
 
 impl<E: PairingEngine> ProverProof<E>
@@ -26,8 +26,9 @@ impl<E: PairingEngine> ProverProof<E>
         oracles: &RandomOracles<E::Fr>,
     ) -> bool
     {
+        let beta0 = oracles.beta[0].to_field();
         // compute ra*zm - ram*z ?= h*v + b*g to verify the first sumcheck argument
-        (oracles.alpha.pow([index.domains.h.size]) - &oracles.beta[0].pow([index.domains.h.size])) *
+        (oracles.alpha.pow([index.domains.h.size]) - &beta0.pow([index.domains.h.size])) *
             &(0..3).map
             (
                 |i|
@@ -42,12 +43,12 @@ impl<E: PairingEngine> ProverProof<E>
                 }
             ).fold(E::Fr::zero(), |x, y| x + &y)
         ==
-        (oracles.alpha - &oracles.beta[0]) *
+        (oracles.alpha - &beta0) *
         &(
-            self.evals.h1 * &index.domains.h.evaluate_vanishing_polynomial(oracles.beta[0]) +
-            &(oracles.beta[0] * &self.evals.g1) +
+            self.evals.h1 * &index.domains.h.evaluate_vanishing_polynomial(beta0) +
+            &(beta0 * &self.evals.g1) +
             &(self.sigma2 * &index.domains.h.size_as_field_element *
-            &(self.evals.w * &index.domains.x.evaluate_vanishing_polynomial(oracles.beta[0]) +
+            &(self.evals.w * &index.domains.x.evaluate_vanishing_polynomial(beta0) +
             &oracles.x_hat_beta1))
         )
     }
@@ -63,12 +64,13 @@ impl<E: PairingEngine> ProverProof<E>
         oracles: &RandomOracles<E::Fr>,
     ) -> bool
     {
+        let beta1 = oracles.beta[1].to_field();
         self.sigma3 * &index.domains.k.size_as_field_element *
-            &((oracles.alpha.pow([index.domains.h.size]) - &oracles.beta[1].pow([index.domains.h.size])))
+            &((oracles.alpha.pow([index.domains.h.size]) - &beta1.pow([index.domains.h.size])))
         ==
-        (oracles.alpha - &oracles.beta[1]) * &(self.evals.h2 *
-            &index.domains.h.evaluate_vanishing_polynomial(oracles.beta[1]) +
-            &self.sigma2 + &(self.evals.g2 * &oracles.beta[1]))
+        (oracles.alpha - &beta1) * &(self.evals.h2 *
+            &index.domains.h.evaluate_vanishing_polynomial(beta1) +
+            &self.sigma2 + &(self.evals.g2 * &beta1))
     }
 
     // This function verifies the prover's third sumcheck argument values
@@ -82,13 +84,17 @@ impl<E: PairingEngine> ProverProof<E>
         oracles: &RandomOracles<E::Fr>
     ) -> bool
     {
+        let beta0 = oracles.beta[0].to_field();
+        let beta1 = oracles.beta[1].to_field();
+        let beta2 = oracles.beta[2].to_field();
+
         let crb: Vec<E::Fr> = (0..3).map
         (
             |i|
             {
-                oracles.beta[1] * &oracles.beta[0] -
-                &(oracles.beta[0] * &self.evals.row[i]) -
-                &(oracles.beta[1] * &self.evals.col[i]) +
+                beta1 * &beta0 -
+                &(beta0 * &self.evals.row[i]) -
+                &(beta1 * &self.evals.col[i]) +
                 &self.evals.rc[i]
             }
         ).collect();
@@ -103,11 +109,11 @@ impl<E: PairingEngine> ProverProof<E>
             }
         ).fold(E::Fr::zero(), |x, y| x + &y);
 
-        index.domains.k.evaluate_vanishing_polynomial(oracles.beta[2]) * &self.evals.h3
+        index.domains.k.evaluate_vanishing_polynomial(beta2) * &self.evals.h3
         ==
-        index.domains.h.evaluate_vanishing_polynomial(oracles.beta[0]) *
-            &(index.domains.h.evaluate_vanishing_polynomial(oracles.beta[1])) *
-            &acc - &((oracles.beta[2] * &self.evals.g3 + &self.sigma3) *
+        index.domains.h.evaluate_vanishing_polynomial(beta0) *
+            &(index.domains.h.evaluate_vanishing_polynomial(beta1)) *
+            &acc - &((beta2 * &self.evals.g3 + &self.sigma3) *
             &crb[0] * &crb[1] * &crb[2])
     }
 
@@ -145,10 +151,12 @@ impl<E: PairingEngine> ProverProof<E>
                 return Err(ProofError::ProofVerification)
             }
 
+            let batch_chal = oracles.batch.to_field();
+
             batch.push
             ((
-                oracles.beta[0],
-                oracles.batch,
+                oracles.beta[0].to_field(),
+                batch_chal,
                 vec!
                 [
                     (x_hat_comm,        oracles.x_hat_beta1, None),
@@ -162,8 +170,8 @@ impl<E: PairingEngine> ProverProof<E>
             ));
             batch.push
             ((
-                oracles.beta[1],
-                oracles.batch,
+                oracles.beta[1].to_field(),
+                batch_chal,
                 vec!
                 [
                     (proof.g2_comm.0,   proof.evals.g2, Some((proof.g2_comm.1, index.domains.h.size()-1))),
@@ -173,8 +181,8 @@ impl<E: PairingEngine> ProverProof<E>
             ));
             batch.push
             ((
-                oracles.beta[2],
-                oracles.batch,
+                oracles.beta[2].to_field(),
+                batch_chal,
                 vec!
                 [
                     (proof.g3_comm.0, proof.evals.g3, Some((proof.g3_comm.1, index.domains.k.size()-1))),
@@ -230,18 +238,18 @@ impl<E: PairingEngine> ProverProof<E>
         // absorb H1, G1 polycommitments
         fq_sponge.absorb_g(&[self.g1_comm.0, self.g1_comm.1, self.h1_comm]);
         // sample beta[0] oracle
-        oracles.beta[0] = fq_sponge.challenge();
+        oracles.beta[0] = ScalarChallenge(fq_sponge.challenge());
         // absorb sigma2 scalar
         fq_sponge.absorb_fr(&self.sigma2);
         fq_sponge.absorb_g(&[self.g2_comm.0, self.g2_comm.1, self.h2_comm]);
         // sample beta[1] oracle
-        oracles.beta[1] = fq_sponge.challenge();
+        oracles.beta[1] = ScalarChallenge(fq_sponge.challenge());
         // absorb sigma3 scalar
         fq_sponge.absorb_fr(&self.sigma3);
         fq_sponge.absorb_g(&[self.g3_comm.0, self.g3_comm.1, self.h3_comm]);
         // sample beta[2] & batch oracles
-        oracles.beta[2] = fq_sponge.challenge();
-        oracles.r_k = fq_sponge.challenge();
+        oracles.beta[2] = ScalarChallenge(fq_sponge.challenge());
+        oracles.r_k = ScalarChallenge(fq_sponge.challenge());
 
         let digest_before_evaluations = fq_sponge.digest();
         oracles.digest_before_evaluations = digest_before_evaluations;
@@ -252,7 +260,7 @@ impl<E: PairingEngine> ProverProof<E>
             s
         };
 
-        let x_hat_beta1 = x_hat.evaluate(oracles.beta[0]);
+        let x_hat_beta1 = x_hat.evaluate(oracles.beta[0].to_field());
         oracles.x_hat_beta1 = x_hat_beta1;
 
         fr_sponge.absorb_evaluations(&x_hat_beta1,&self.evals);

--- a/pairing/protocol/src/verifier.rs
+++ b/pairing/protocol/src/verifier.rs
@@ -26,7 +26,7 @@ impl<E: PairingEngine> ProverProof<E>
         oracles: &RandomOracles<E::Fr>,
     ) -> bool
     {
-        let beta0 = oracles.beta[0].to_field();
+        let beta0 = oracles.beta[0].to_field(&index.endo_r);
         // compute ra*zm - ram*z ?= h*v + b*g to verify the first sumcheck argument
         (oracles.alpha.pow([index.domains.h.size]) - &beta0.pow([index.domains.h.size])) *
             &(0..3).map
@@ -64,7 +64,7 @@ impl<E: PairingEngine> ProverProof<E>
         oracles: &RandomOracles<E::Fr>,
     ) -> bool
     {
-        let beta1 = oracles.beta[1].to_field();
+        let beta1 = oracles.beta[1].to_field(&index.endo_r);
         self.sigma3 * &index.domains.k.size_as_field_element *
             &((oracles.alpha.pow([index.domains.h.size]) - &beta1.pow([index.domains.h.size])))
         ==
@@ -84,9 +84,9 @@ impl<E: PairingEngine> ProverProof<E>
         oracles: &RandomOracles<E::Fr>
     ) -> bool
     {
-        let beta0 = oracles.beta[0].to_field();
-        let beta1 = oracles.beta[1].to_field();
-        let beta2 = oracles.beta[2].to_field();
+        let beta0 = oracles.beta[0].to_field(&index.endo_r);
+        let beta1 = oracles.beta[1].to_field(&index.endo_r);
+        let beta2 = oracles.beta[2].to_field(&index.endo_r);
 
         let crb: Vec<E::Fr> = (0..3).map
         (
@@ -151,11 +151,11 @@ impl<E: PairingEngine> ProverProof<E>
                 return Err(ProofError::ProofVerification)
             }
 
-            let batch_chal = oracles.batch.to_field();
+            let batch_chal = oracles.batch.to_field(&index.endo_r);
 
             batch.push
             ((
-                oracles.beta[0].to_field(),
+                oracles.beta[0].to_field(&index.endo_r),
                 batch_chal,
                 vec!
                 [
@@ -170,7 +170,7 @@ impl<E: PairingEngine> ProverProof<E>
             ));
             batch.push
             ((
-                oracles.beta[1].to_field(),
+                oracles.beta[1].to_field(&index.endo_r),
                 batch_chal,
                 vec!
                 [
@@ -181,7 +181,7 @@ impl<E: PairingEngine> ProverProof<E>
             ));
             batch.push
             ((
-                oracles.beta[2].to_field(),
+                oracles.beta[2].to_field(&index.endo_r),
                 batch_chal,
                 vec!
                 [
@@ -260,7 +260,7 @@ impl<E: PairingEngine> ProverProof<E>
             s
         };
 
-        let x_hat_beta1 = x_hat.evaluate(oracles.beta[0].to_field());
+        let x_hat_beta1 = x_hat.evaluate(oracles.beta[0].to_field(&index.endo_r));
         oracles.x_hat_beta1 = x_hat_beta1;
 
         fr_sponge.absorb_evaluations(&x_hat_beta1,&self.evals);


### PR DESCRIPTION
This PR defines an injective map f: 2^128 -> F, and replaces a subset of the challenges `c` in marlin with `f(c)`. 

The reason is that for these challenges, the verifier previously computed `c * P` (for some point `P`), but, it is much cheaper to compute `f(c) * P` inside the circuit. Therefore, one thinks of the value `c` squeezed from the sponge as an encoding of the field element `f(c)`.

Or another way of thinking about it is that instead of sampling challenges as a uniform random 128 bit string, we select a uniformly random element from the set { f(c) | c a 128 bit challenge } and since f is injective this is ok.

The technique (which uses an endomorphism on the curve) is described in the halo paper.