### PR TITLE
Separate logic for initialising oracle values and actual verification

### DIFF
--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -17,8 +17,123 @@ use rand_core::OsRng;
 type Fr<G> = <G as AffineCurve>::ScalarField;
 type Fq<G> = <G as AffineCurve>::BaseField;
 
+#[derive(Clone)]
+pub struct CachedValues<Fs> {
+    pub zeta1: Fs,
+    pub zetaw: Fs,
+    pub alpha: Vec<Fs>,
+}
+
 impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : QnrField
 {
+
+    // This function queries random oracle values from non-interactive
+    // argument context by verifier
+    // This setup is partial; the values `u` and `v` are initialized to zero so
+    // that the evaluations it uses can be cached for use in the verification.
+    pub fn setupOracles
+        <EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>,
+         EFrSponge: FrSponge<Fr<G>>,
+        >
+    (
+        &self,
+        index: &Index<G>,
+        p_comm: &PolyComm<G>,
+    ) -> (EFqSponge, RandomOracles<Fr<G>>)
+    {
+        // Run random oracle argument to sample verifier oracles
+        let mut oracles = RandomOracles::<Fr<G>>::zero();
+        let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
+        // absorb the public input, l, r, o polycommitments into the argument
+        fq_sponge.absorb_g(&p_comm.unshifted);
+        fq_sponge.absorb_g(&self.l_comm.unshifted);
+        fq_sponge.absorb_g(&self.r_comm.unshifted);
+        fq_sponge.absorb_g(&self.o_comm.unshifted);
+        // sample beta, gamma oracles
+        oracles.beta = fq_sponge.challenge();
+        oracles.gamma = fq_sponge.challenge();
+        // absorb the z commitment into the argument and query alpha
+        fq_sponge.absorb_g(&self.z_comm.unshifted);
+        oracles.alpha = fq_sponge.challenge();
+        // absorb the polycommitments into the argument and sample zeta
+        fq_sponge.absorb_g(&self.t_comm.unshifted);
+        oracles.zeta = ScalarChallenge(fq_sponge.challenge()).to_field(&index.srs.get_ref().endo_r);
+
+        (fq_sponge, oracles)
+    }
+
+    pub fn genCachedValues
+    (
+        index: &Index<G>,
+        oracles: &RandomOracles<Fr<G>>
+    ) -> CachedValues<Fr<G>>
+    {
+        let n = index.domain.size;
+        let zeta1 = oracles.zeta.pow(&[n]);
+        let zetaw = oracles.zeta * &index.domain.group_gen;
+        let mut alpha = oracles.alpha;
+        let alpha = (0..4).map(|_| {alpha *= &oracles.alpha; alpha}).collect::<Vec<_>>();
+
+        CachedValues {zeta1, zetaw, alpha}
+    }
+
+    pub fn p_eval
+    (
+        &self,
+        index: &Index<G>,
+        oracles: &RandomOracles<Fr<G>>,
+        cachedValues: &CachedValues<Fr<G>>,
+        p_eval: &mut[Vec<Fr<G>>; 2],
+    ) -> ()
+    {
+        let n = index.domain.size;
+
+        // compute Lagrange base evaluation denominators
+        let w = (0..self.public.len()).zip(index.domain.elements()).map(|(_,w)| w).collect::<Vec<_>>();
+        let mut lagrange = w.iter().map(|w| oracles.zeta - w).collect::<Vec<_>>();
+        (0..self.public.len()).zip(w.iter()).for_each(|(_,w)| lagrange.push(cachedValues.zetaw - w));
+        algebra::fields::batch_inversion::<Fr<G>>(&mut lagrange);
+
+        // evaluate public input polynomials
+        // NOTE: this works only in the case when the poly segment size is not smaller than that of the domain
+        if self.public.len() > 0
+        {
+            (*p_eval)[0] = vec![(self.public.iter().zip(lagrange.iter()).
+                zip(index.domain.elements()).map(|((p, l), w)| -*l * p * &w).
+                fold(Fr::<G>::zero(), |x, y| x + &y)) * &(cachedValues.zeta1 - &Fr::<G>::one()) * &index.domain.size_inv];
+            (*p_eval)[1] = vec![(self.public.iter().zip(lagrange[self.public.len()..].iter()).
+                zip(index.domain.elements()).map(|((p, l), w)| -*l * p * &w).
+                fold(Fr::<G>::zero(), |x, y| x + &y)) * &index.domain.size_inv * &(cachedValues.zetaw.pow(&[n as u64]) - &Fr::<G>::one())];
+        }
+    }
+
+    // This function constructs the values `u` and `v` in the random oracle.
+    pub fn finalizeOracles
+        <EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>,
+         EFrSponge: FrSponge<Fr<G>>,
+        >
+    (
+        &self,
+        index: &Index<G>,
+        p_eval: &[Vec<Fr<G>>; 2],
+        fq_sponge: &EFqSponge,
+        oracles: &mut RandomOracles<Fr<G>>,
+    ) -> ()
+    {
+        let mut fr_sponge =
+        {
+            let mut s = EFrSponge::new(index.fr_sponge_params.clone());
+            s.absorb(&fq_sponge.clone().digest());
+            s
+        };
+
+        for i in 0..2 {fr_sponge.absorb_evaluations(&p_eval[i], &self.evals[i])}
+
+        // query opening scalar challenges
+        oracles.v = fr_sponge.challenge().to_field(&index.srs.get_ref().endo_r);
+        oracles.u = fr_sponge.challenge().to_field(&index.srs.get_ref().endo_r);
+    }
+
     // This function verifies the batch of zk-proofs
     //     proofs: vector of Plonk proofs
     //     index: Index
@@ -45,64 +160,19 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : QnrField
                 *p_comm = PolyComm::<G>::multi_scalar_mul
                     (&index.srs.get_ref().lgr_comm.iter().map(|l| l).collect(), &proof.public.iter().map(|s| -*s).collect());
 
-                // Run random oracle argument to sample verifier oracles
-                let mut oracles = RandomOracles::<Fr<G>>::zero();
-                let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
-                // absorb the public input, l, r, o polycommitments into the argument
-                fq_sponge.absorb_g(&p_comm.unshifted);
-                fq_sponge.absorb_g(&proof.l_comm.unshifted);
-                fq_sponge.absorb_g(&proof.r_comm.unshifted);
-                fq_sponge.absorb_g(&proof.o_comm.unshifted);
-                // sample beta, gamma oracles
-                oracles.beta = fq_sponge.challenge();
-                oracles.gamma = fq_sponge.challenge();
-                // absorb the z commitment into the argument and query alpha
-                fq_sponge.absorb_g(&proof.z_comm.unshifted);
-                oracles.alpha = fq_sponge.challenge();
-                // absorb the polycommitments into the argument and sample zeta
-                fq_sponge.absorb_g(&proof.t_comm.unshifted);
-                oracles.zeta = ScalarChallenge(fq_sponge.challenge()).to_field(&index.srs.get_ref().endo_r);
-                let mut fr_sponge =
-                {
-                    let mut s = EFrSponge::new(index.fr_sponge_params.clone());
-                    s.absorb(&fq_sponge.clone().digest());
-                    s
-                };
-
+                let (mut fq_sponge, mut oracles) = proof.setupOracles::<EFqSponge, EFrSponge>(index, p_comm);
                 // prepare some often used values
-                let zeta1 = oracles.zeta.pow(&[n]);
-                let zetaw = oracles.zeta * &index.domain.group_gen;
-                let mut alpha = oracles.alpha;
-                let alpha = (0..4).map(|_| {alpha *= &oracles.alpha; alpha}).collect::<Vec<_>>();
-
-                // compute Lagrange base evaluation denominators
-                let w = (0..proof.public.len()).zip(index.domain.elements()).map(|(_,w)| w).collect::<Vec<_>>();
-                let mut lagrange = w.iter().map(|w| oracles.zeta - w).collect::<Vec<_>>();
-                (0..proof.public.len()).zip(w.iter()).for_each(|(_,w)| lagrange.push(zetaw - w));
-                algebra::fields::batch_inversion::<Fr<G>>(&mut lagrange);
-
-                // evaluate public input polynomials
-                // NOTE: this works only in the case when the poly segment size is not smaller than that of the domain
-                if proof.public.len() > 0
+                let cachedValues = ProverProof::<G>::genCachedValues(index, &oracles);
+                proof.p_eval(index, &oracles, &cachedValues, p_eval);
                 {
-                    (*p_eval)[0] = vec![(proof.public.iter().zip(lagrange.iter()).
-                        zip(index.domain.elements()).map(|((p, l), w)| -*l * p * &w).
-                        fold(Fr::<G>::zero(), |x, y| x + &y)) * &(zeta1 - &Fr::<G>::one()) * &index.domain.size_inv];
-                    (*p_eval)[1] = vec![(proof.public.iter().zip(lagrange[proof.public.len()..].iter()).
-                        zip(index.domain.elements()).map(|((p, l), w)| -*l * p * &w).
-                        fold(Fr::<G>::zero(), |x, y| x + &y)) * &index.domain.size_inv * &(zetaw.pow(&[n as u64]) - &Fr::<G>::one())];
+                    proof.finalizeOracles::<EFqSponge, EFrSponge>(index, p_eval, &mut fq_sponge, &mut oracles);
                 }
-                for i in 0..2 {fr_sponge.absorb_evaluations(&p_eval[i], &proof.evals[i])}
-
-                // query opening scaler challenges
-                oracles.v = fr_sponge.challenge().to_field(&index.srs.get_ref().endo_r);
-                oracles.u = fr_sponge.challenge().to_field(&index.srs.get_ref().endo_r);
 
                 // evaluate committed polynoms
                 let evlp =
                 [
                     oracles.zeta.pow(&[index.max_poly_size as u64]),
-                    zetaw.pow(&[index.max_poly_size as u64])
+                    cachedValues.zetaw.pow(&[index.max_poly_size as u64])
                 ];
 
                 let evals = (0..2).map
@@ -142,13 +212,13 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : QnrField
                 // generic constraint/permutation linearization scalars
                 s.extend(&ConstraintSystem::gnrc_scalars(&evals[0]));
                 // poseidon constraint linearization scalars
-                s.extend(&ConstraintSystem::psdn_scalars(&evals, &alpha));
+                s.extend(&ConstraintSystem::psdn_scalars(&evals, &cachedValues.alpha));
                 // EC addition constraint linearization scalars
-                s.extend(&ConstraintSystem::ecad_scalars(&evals, &alpha));
+                s.extend(&ConstraintSystem::ecad_scalars(&evals, &cachedValues.alpha));
                 // EC variable base scalar multiplication constraint linearization scalars
-                s.extend(&ConstraintSystem::vbmul_scalars(&evals, &alpha));
+                s.extend(&ConstraintSystem::vbmul_scalars(&evals, &cachedValues.alpha));
                 // group endomorphism optimised variable base scalar multiplication constraint linearization scalars
-                s.extend(&ConstraintSystem::endomul_scalars(&evals, index.srs.get_ref().endo_r, &alpha));
+                s.extend(&ConstraintSystem::endomul_scalars(&evals, index.srs.get_ref().endo_r, &cachedValues.alpha));
 
                 *f_comm = PolyComm::multi_scalar_mul(&p, &s);
 
@@ -160,17 +230,17 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : QnrField
                     &(evals[0].r + &(oracles.beta * &evals[0].sigma2) + &oracles.gamma) *
                     (evals[0].o + &oracles.gamma) * &evals[1].z * &oracles.alpha)
                     -
-                    evals[0].t * &(zeta1 - &Fr::<G>::one()))
+                    evals[0].t * &(cachedValues.zeta1 - &Fr::<G>::one()))
                     *
                     &(oracles.zeta - &Fr::<G>::one())
                 !=
-                    (zeta1 - &Fr::<G>::one()) * &alpha[0]
+                    (cachedValues.zeta1 - &Fr::<G>::one()) * &cachedValues.alpha[0]
                 {return Err(ProofError::ProofVerification)}
 
                 // prepare for the opening proof verification
                 Ok((
                     fq_sponge,
-                    vec![oracles.zeta, zetaw],
+                    vec![oracles.zeta, cachedValues.zetaw],
                     oracles.v,
                     oracles.u,
                     vec!


### PR DESCRIPTION
This is needed for the OCaml bindings, so that we can construct a properly-initialised oracles value.