### PR TITLE
batch verification across different vks

### DIFF
--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -547,11 +547,12 @@ impl<G: CommitmentCurve> SRS<G> where G::ScalarField : QnrField {
 
         // TODO: This will need adjusting
         let padding = padded_length - nonzero_length;
-        let mut points = self.g.clone();
+        let mut points = vec![self.h];
+        points.extend(self.g.clone());
         points.extend(vec![G::zero(); padding]);
 
-        points.push(self.h);
         let mut scalars = vec![Fr::<G>::zero(); padded_length + 1];
+        assert_eq!(scalars.len(), points.len());
 
         // sample randomiser to scale the proofs with
         let rand_base = Fr::<G>::rand(rng);
@@ -606,13 +607,13 @@ impl<G: CommitmentCurve> SRS<G> where G::ScalarField : QnrField {
                 let terms: Vec<_> = s.par_iter().map(|s| sg_rand_base_i * s).collect();
 
                 for (i, term) in terms.iter().enumerate() {
-                    scalars[i] += term;
+                    scalars[i + 1] += term;
                 }
             }
 
             // TERM
             // - rand_base_i * z2 * H
-            scalars[padded_length] -= &(rand_base_i * &opening.z2);
+            scalars[0] -= &(rand_base_i * &opening.z2);
 
             // TERM
             // -rand_base_i * (z1 * b0 * U)

--- a/dlog/commitment/src/srs.rs
+++ b/dlog/commitment/src/srs.rs
@@ -78,8 +78,8 @@ impl<G: CommitmentCurve> SRS<G> where G::BaseField : PrimeField, G::ScalarField 
 
         let mut srs = SRS
         {
-            g: v[0..depth].iter().map(|e| *e).collect(),
-            h: v[depth],
+            g: v[1..depth + 1].iter().map(|e| *e).collect(),
+            h: v[0],
             lgr_comm: Vec::new(),
             endo_r, endo_q
         };

--- a/dlog/tests/marlin_group_addition.rs
+++ b/dlog/tests/marlin_group_addition.rs
@@ -185,6 +185,8 @@ where <Fr as std::str::FromStr>::Err : std::fmt::Debug
     let group_map = <Affine as CommitmentCurve>::Map::setup();
     let mut start = Instant::now();
 
+    let verifier_index = index.verifier_index();
+
     let tests = 0..1000;
     let mut batch = Vec::new();
     for test in tests.clone()
@@ -218,18 +220,17 @@ where <Fr as std::str::FromStr>::Err : std::fmt::Debug
         };
 
         // add the proof to the batch
-        batch.push(
+        batch.push((&verifier_index,
             ProverProof::create::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fr, SC>>(
-                &group_map, &witness, &index, vec![prev], rng).unwrap());
+                &group_map, &witness, &index, vec![prev], rng).unwrap()));
 
         print!("{:?}\r", test);
         io::stdout().flush().unwrap();
     }
     println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());
 
-    let verifier_index = index.verifier_index();
     // verify one proof serially
-    match ProverProof::verify::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fr, SC>>(&group_map, &vec![batch[0].clone()], &verifier_index, rng)
+    match ProverProof::verify::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fr, SC>>(&group_map, &vec![batch[0].clone()], rng)
     {
         false => {panic!("Failure verifying the prover's proof")},
         true => {}
@@ -238,7 +239,7 @@ where <Fr as std::str::FromStr>::Err : std::fmt::Debug
     // verify the proofs in batch
     println!("{}", "Verifier zk-proofs verification".green());
     start = Instant::now();
-    match ProverProof::verify::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fr, SC>>(&group_map, &batch, &verifier_index, rng)
+    match ProverProof::verify::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fr, SC>>(&group_map, &batch, rng)
     {
         false => {panic!("Failure verifying the prover's proofs in batch")},
         true => {println!("{}{:?}", "Execution time: ".yellow(), start.elapsed());}

--- a/dlog/tests/marlin_reduction.rs
+++ b/dlog/tests/marlin_reduction.rs
@@ -164,24 +164,26 @@ where <Fr as std::str::FromStr>::Err : std::fmt::Debug
       ( chals, comm )
     };
 
-    batch.push(ProverProof::create::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fr, SC>>(&group_map, &witness, &index, vec![prev], rng).unwrap());
+    let ver_indexes = indexes.iter().map(|ind| ind.verifier_index()).collect::<Vec<_>>();
+    let mut batch = Vec::new();
+    for (prind, vrind) in indexes.iter().zip(ver_indexes.iter())
+    {
+        batch.push
+        ((
+            vrind,
+            ProverProof::create::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fr, SC>>(&group_map, &witness, &prind, vec![prev.clone()], rng).unwrap()
+        ));
+    }
     let prover_time = start.elapsed();
 
-    let verifier_index = index.verifier_index();
     start = Instant::now();
-    match ProverProof::verify::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fr, SC>>(&group_map, &batch, &verifier_index, rng)
+    match ProverProof::verify::<DefaultFqSponge<Bn_382GParameters, SC>, DefaultFrSponge<Fr, SC>>(&group_map, &batch, rng)
     {
         false => {panic!("Failure verifying the prover's proofs in batch")},
         true => {}
     }
     let verifier_time = start.elapsed();
 
-    if srs_size == 1000
-    {
-        println!("{}{:?}", "H domain size: ".magenta(), index.domains.h.size);
-        println!("{}{:?}", "K domain size: ".magenta(), index.domains.k.size);
-        println!();
-    }
-    println!("{:?}\t\t\t{:?}\t\t\t{:?}", index.srs.get_ref().g.len(), prover_time, verifier_time);
+    println!("{:?}\t\t\t{:?}\t\t\t{:?}", min_srs_size, prover_time, verifier_time);
     (prover_time, verifier_time)
 }


### PR DESCRIPTION
This PR changes the marlin verify function to batch verification across proofs with different verification indexes. It requires that the indexes all have the same CRS length. This limitation shouldn't be necessary but I couldn't get it to work for now.

It also reorganizes the CRS so that if `n < m` then `create(n, 0, 0).g` is a prefix of `create(m, 0, 0).g` and `create(n, 0, 0).h == create(m, 0, 0).h`. This property is useful for batching verification across indexes of varying CRS length.