### PR TITLE
additions for Plonk Snarky bindings and for recursion

### DIFF
--- a/circuits/plonk/src/gate.rs
+++ b/circuits/plonk/src/gate.rs
@@ -5,7 +5,7 @@ This source file implements Plonk constraint gate primitive.
 *****************************************************************************************************************/
 
 use algebra::FftField;
-pub use super::{wires::GateWires, constraints::ConstraintSystem};
+pub use super::{wires::{*}, constraints::ConstraintSystem};
 
 #[derive(Clone)]
 #[derive(PartialEq)]
@@ -70,4 +70,12 @@ impl<F: FftField> CircuitGate<F>
             GateType::Endomul4  => self.verify_endomul4(next, witness),
         }
     }
+}
+
+#[derive(Clone)]
+pub struct Gate<F: FftField>
+{
+    pub typ: GateType,      // type of the gate
+    pub wires: Wires,       // gate wires
+    pub c: Vec<F>,          // constraints vector
 }

--- a/circuits/plonk/src/wires.rs
+++ b/circuits/plonk/src/wires.rs
@@ -29,3 +29,22 @@ impl GateWires
         }
     }
 }
+
+#[derive(Clone, Copy)]
+pub enum Col {L, R, O}
+
+#[derive(Clone, Copy)]
+pub struct Wire
+{
+    pub row: usize,         // wire row
+    pub col: Col,           // wire column
+}
+
+#[derive(Clone, Copy)]
+pub struct Wires
+{
+    pub row: usize,         // gate wire row
+    pub l: Wire,            // left input wire permutation
+    pub r: Wire,            // right input wire permutation
+    pub o: Wire,            // output input wire permutation
+}

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -17,13 +17,6 @@ use rand_core::OsRng;
 type Fr<G> = <G as AffineCurve>::ScalarField;
 type Fq<G> = <G as AffineCurve>::BaseField;
 
-#[derive(Clone)]
-pub struct CachedValues<Fs> {
-    pub zeta1: Fs,
-    pub zetaw: Fs,
-    pub alpha: Vec<Fs>,
-}
-
 impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : QnrField
 {
 


### PR DESCRIPTION
This PR implements the following additions for SNARK recursion and Plonk - Snarky bindings:

* Gate and Wire primitives for translating Snarky's wire equivalence classes into Plonk constraints
* Access to the sponge digest before evaluations from Snarky
