### PR TITLE
Tweaks for circuits

### DIFF
--- a/circuits/plonk/Cargo.toml
+++ b/circuits/plonk/Cargo.toml
@@ -13,6 +13,7 @@ ff-fft = { path = "../../../zexe/ff-fft" }
 oracle = { path = "../../oracle" }
 rand_core = { version = "0.5" }
 array-init = { version = "0.1.1" }
+rayon = { version = "1" }
 blake2 = "0.7"
 
 num-derive = "0.3"

--- a/circuits/plonk/Cargo.toml
+++ b/circuits/plonk/Cargo.toml
@@ -14,3 +14,6 @@ oracle = { path = "../../oracle" }
 rand_core = { version = "0.5" }
 array-init = { version = "0.1.1" }
 blake2 = "0.7"
+
+num-derive = "0.3"
+num-traits = "0.2"

--- a/circuits/plonk/src/constraints.rs
+++ b/circuits/plonk/src/constraints.rs
@@ -218,21 +218,6 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
             !self.gates[i].verify(if i+1==self.gates.len() {&self.gates[i]}
                                                       else {&self.gates[i+1]}, witness, &self)
             {
-                for &i in [ i, 194037 ].iter() {
-                    println!("fail gate[{}] =", i);
-                    println!("typ = {:?}", self.gates[i].typ);
-                    println!("wires = {:?}", self.gates[i].wires);
-                    println!("c");
-                    for x in self.gates[i].c.iter() {
-                        println!("{}", x);
-                    }
-                    println!("{} vs {}", witness[self.gates[i].wires.l.0], witness[self.gates[i].wires.l.1]);
-                    println!("{} vs {}", witness[self.gates[i].wires.r.0], witness[self.gates[i].wires.r.1]);
-                    println!("{} vs {}", witness[self.gates[i].wires.o.0], witness[self.gates[i].wires.o.1]);
-                    println!("public input = {}", self.public);
-                    println!("gates = {}", self.gates.len());
-                    println!("domain = {}", self.domain.d1.size());
-                }
                 return false
             }
         }

--- a/circuits/plonk/src/constraints.rs
+++ b/circuits/plonk/src/constraints.rs
@@ -205,9 +205,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         witness: &Vec<F>
     ) -> bool
     {
-        println!("verify witness len {}", witness.len());
         if witness.len() != 3*self.domain.d1.size() {return false}
-        println!("self.public = {}", self.public);
         for i in self.public..self.gates.len()
         {
             if
@@ -220,16 +218,21 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
             !self.gates[i].verify(if i+1==self.gates.len() {&self.gates[i]}
                                                       else {&self.gates[i+1]}, witness, &self)
             {
-                println!("fail gate[{}] =", i);
-                println!("typ = {:?}", self.gates[i].typ);
-                println!("wires = {:?}", self.gates[i].wires);
-                println!("c");
-                for x in self.gates[i].c.iter() {
-                    println!("{}", x);
+                for &i in [ i, 194037 ].iter() {
+                    println!("fail gate[{}] =", i);
+                    println!("typ = {:?}", self.gates[i].typ);
+                    println!("wires = {:?}", self.gates[i].wires);
+                    println!("c");
+                    for x in self.gates[i].c.iter() {
+                        println!("{}", x);
+                    }
+                    println!("{} vs {}", witness[self.gates[i].wires.l.0], witness[self.gates[i].wires.l.1]);
+                    println!("{} vs {}", witness[self.gates[i].wires.r.0], witness[self.gates[i].wires.r.1]);
+                    println!("{} vs {}", witness[self.gates[i].wires.o.0], witness[self.gates[i].wires.o.1]);
+                    println!("public input = {}", self.public);
+                    println!("gates = {}", self.gates.len());
+                    println!("domain = {}", self.domain.d1.size());
                 }
-                println!("{} vs {}", witness[self.gates[i].wires.l.0], witness[self.gates[i].wires.l.1]);
-                println!("{} vs {}", witness[self.gates[i].wires.r.0], witness[self.gates[i].wires.r.1]);
-                println!("{} vs {}", witness[self.gates[i].wires.o.0], witness[self.gates[i].wires.o.1]);
                 return false
             }
         }

--- a/circuits/plonk/src/constraints.rs
+++ b/circuits/plonk/src/constraints.rs
@@ -205,7 +205,9 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         witness: &Vec<F>
     ) -> bool
     {
+        println!("verify witness len {}", witness.len());
         if witness.len() != 3*self.domain.d1.size() {return false}
+        println!("self.public = {}", self.public);
         for i in self.public..self.gates.len()
         {
             if
@@ -215,8 +217,19 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
             witness[self.gates[i].wires.o.1] != witness[self.gates[i].wires.o.0] ||
 
             // verify witness against constraints
-            !self.gates[i].verify(if i+1==self.gates.len() {&self.gates[i]} else {&self.gates[i+1]}, witness, &self)
+            !self.gates[i].verify(if i+1==self.gates.len() {&self.gates[i]}
+                                                      else {&self.gates[i+1]}, witness, &self)
             {
+                println!("fail gate[{}] =", i);
+                println!("typ = {:?}", self.gates[i].typ);
+                println!("wires = {:?}", self.gates[i].wires);
+                println!("c");
+                for x in self.gates[i].c.iter() {
+                    println!("{}", x);
+                }
+                println!("{} vs {}", witness[self.gates[i].wires.l.0], witness[self.gates[i].wires.l.1]);
+                println!("{} vs {}", witness[self.gates[i].wires.r.0], witness[self.gates[i].wires.r.1]);
+                println!("{} vs {}", witness[self.gates[i].wires.o.0], witness[self.gates[i].wires.o.1]);
                 return false
             }
         }

--- a/circuits/plonk/src/gate.rs
+++ b/circuits/plonk/src/gate.rs
@@ -5,7 +5,7 @@ This source file implements Plonk constraint gate primitive.
 *****************************************************************************************************************/
 
 use algebra::FftField;
-pub use super::{wires::GateWires, constraints::ConstraintSystem};
+pub use super::{wires::{*}, constraints::ConstraintSystem};
 
 #[derive(Clone)]
 #[derive(PartialEq)]
@@ -70,4 +70,12 @@ impl<F: FftField> CircuitGate<F>
             GateType::Endomul4  => self.verify_endomul4(next, witness),
         }
     }
+}
+
+#[derive(Clone)]
+pub struct Gate<F: FftField>
+{
+    pub typ: GateType,      // type of the gate
+    pub wires: Wires,       // gate wires
+    pub c: Vec<F>,          // constraints vector
 }

--- a/circuits/plonk/src/gate.rs
+++ b/circuits/plonk/src/gate.rs
@@ -10,7 +10,7 @@ use std::io::{Read, Result as IoResult, Write, Error, ErrorKind};
 use algebra::bytes::{FromBytes, ToBytes};
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[derive(PartialEq)]
 #[derive(FromPrimitive, ToPrimitive)]
 pub enum GateType
@@ -45,7 +45,8 @@ pub struct CircuitGate<F: FftField>
 impl<F: FftField> ToBytes for CircuitGate<F> {
     #[inline]
     fn write<W: Write>(&self, mut w: W) -> IoResult<()> {
-        ToPrimitive::to_u8(&self.typ).write(&mut w)?;
+        let typ : u8 = ToPrimitive::to_u8(&self.typ).unwrap();
+        typ.write(&mut w)?;
         self.wires.write(&mut w)?;
 
         (self.c.len() as u8).write(&mut w)?;
@@ -59,8 +60,9 @@ impl<F: FftField> ToBytes for CircuitGate<F> {
 impl<F: FftField> FromBytes for CircuitGate<F> {
     #[inline]
     fn read<R: Read>(mut r: R) -> IoResult<Self> {
+        let code = u8::read(&mut r)?;
         let typ =
-            match FromPrimitive::from_u8(u8::read(&mut r)?) {
+            match FromPrimitive::from_u8(code) {
                 Some(x) => Ok(x),
                 None => Err(Error::new(ErrorKind::Other, "Invalid gate type"))
             }?;

--- a/circuits/plonk/src/lib.rs
+++ b/circuits/plonk/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate num_derive;
+
 pub mod gate;
 pub mod gates;
 pub mod constraints;

--- a/circuits/plonk/src/polynomials/endosclmul.rs
+++ b/circuits/plonk/src/polynomials/endosclmul.rs
@@ -21,7 +21,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         {return (self.emul1l.clone(), self.emul3l.clone())}
 
         let one = Evaluations::<F, D<F>>::from_vec_and_domain(vec![F::one(); self.domain.d4.size as usize], self.domain.d4);
-        let xr = &(&polys.d8.this.r.pow(2) - &polys.d8.this.l) - &polys.d8.next.r;
+        let xr = &(&polys.d8.this.r.square() - &polys.d8.this.l) - &polys.d8.next.r;
         let t = &polys.d8.this.l - &xr;
         let u = &polys.d8.this.o.scale((2 as u64).into()) - &(&t * &polys.d8.this.r);
 
@@ -41,7 +41,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
                 &(&polys.d4.this.o * &(&polys.d4.this.l.scale((2 as u64).into()) - &one))) * &self.emul2l)
             ,
             // u^2 - t^2 * (xR + xP + xS)
-            &(&(&u.pow(2) - &(&t.pow(2) * &(&(&xr + &polys.d8.this.l) + &polys.d8.next.l))).scale(alpha[1])
+            &(&(&u.square() - &(&t.square() * &(&(&xr + &polys.d8.this.l) + &polys.d8.next.l))).scale(alpha[1])
             +
             // (xP - xS) * u - t * (yS + yP)
             &(&(&(&polys.d8.this.l - &polys.d8.next.l) * &u) - &(&t * &(&polys.d8.this.o + &polys.d8.next.o))).scale(alpha[2]))

--- a/circuits/plonk/src/polynomials/poseidon.rs
+++ b/circuits/plonk/src/polynomials/poseidon.rs
@@ -10,6 +10,7 @@ use oracle::{utils::{PolyUtils, EvalUtils}, poseidon::{PlonkSpongeConstants,sbox
 use crate::polynomial::WitnessOverDomains;
 use crate::constraints::ConstraintSystem;
 use crate::scalars::ProofEvaluations;
+use rayon::prelude::*;
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> 
 {
@@ -24,7 +25,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         if self.psm.is_zero() {return (self.ps4.clone(), self.ps8.clone(), DensePolynomial::<F>::zero())}
 
         let mut lro = [polys.d8.this.l.clone(), polys.d8.this.r.clone(), polys.d8.this.o.clone()];
-        lro.iter_mut().for_each(|p| p.evals.iter_mut().for_each(|p| *p = sbox::<F, PlonkSpongeConstants>(*p)));
+        lro.iter_mut().for_each(|p| p.evals.par_iter_mut().for_each(|p| *p = sbox::<F, PlonkSpongeConstants>(*p)));
 
         let scalers = (0..params.mds.len()).
             map(|i| (0..params.mds[i].len()).fold(F::zero(), |x, j| alpha[j+1] * params.mds[j][i] + x)).

--- a/circuits/plonk/src/polynomials/varbasemul.rs
+++ b/circuits/plonk/src/polynomials/varbasemul.rs
@@ -21,7 +21,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
         let one = Evaluations::<F, D<F>>::from_vec_and_domain(vec![F::one(); self.domain.d4.size as usize], self.domain.d4);
 
         // 2*xP - λ1^2 + xT
-        let tmp = &(&polys.d8.this.l.scale((2 as u64).into()) - &polys.d8.this.r.pow(2)) + &polys.d8.next.r;
+        let tmp = &(&polys.d8.this.l.scale((2 as u64).into()) - &polys.d8.this.r.square()) + &polys.d8.next.r;
 
         (
             // verify booleanity of the scalar bit
@@ -35,9 +35,9 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F>
             ,
             &(&(
                 // (2*yP - (2*xP - λ1^2 + xT) × λ1)^2 - (λ1^2 - xT + xS) * (2*xP - λ1^2 + xT)^2
-                &(&polys.d8.this.o.scale((2 as u64).into()) - &(&tmp * &polys.d8.this.r)).pow(2)
+                &(&polys.d8.this.o.scale((2 as u64).into()) - &(&tmp * &polys.d8.this.r)).square()
                 -
-                &(&(&(&polys.d8.this.r.pow(2) - &polys.d8.next.r) + &polys.d8.next.l) * &tmp.pow(2))
+                &(&(&(&polys.d8.this.r.square() - &polys.d8.next.r) + &polys.d8.next.l) * &tmp.square())
             ).scale(alpha[1])
             +
             &(

--- a/circuits/plonk/src/scalars.rs
+++ b/circuits/plonk/src/scalars.rs
@@ -23,6 +23,7 @@ pub struct RandomOracles<F: Field>
 {
     pub beta: F,
     pub gamma: F,
+    pub alpha_chal: ScalarChallenge<F>,
     pub alpha: F,
     pub zeta: F,
     pub v: F,
@@ -45,6 +46,7 @@ impl<F: Field> RandomOracles<F>
             zeta: F::zero(),
             v: F::zero(),
             u: F::zero(),
+            alpha_chal: c,
             zeta_chal: c,
             v_chal: c,
             u_chal: c,

--- a/circuits/plonk/src/scalars.rs
+++ b/circuits/plonk/src/scalars.rs
@@ -5,6 +5,7 @@ This source file implements Plonk prover polynomial evaluations primitive.
 *****************************************************************************************************************/
 
 use algebra::Field;
+use oracle::sponge::ScalarChallenge;
 
 #[derive(Clone)]
 pub struct ProofEvaluations<Fs> {
@@ -26,12 +27,16 @@ pub struct RandomOracles<F: Field>
     pub zeta: F,
     pub v: F,
     pub u: F,
+    pub zeta_chal: ScalarChallenge<F>,
+    pub v_chal: ScalarChallenge<F>,
+    pub u_chal: ScalarChallenge<F>,
 }
 
 impl<F: Field> RandomOracles<F>
 {
     pub fn zero () -> Self
     {
+        let c = ScalarChallenge(F::zero());
         Self
         {
             beta: F::zero(),
@@ -40,6 +45,9 @@ impl<F: Field> RandomOracles<F>
             zeta: F::zero(),
             v: F::zero(),
             u: F::zero(),
+            zeta_chal: c,
+            v_chal: c,
+            u_chal: c,
         }
     }
 }

--- a/circuits/plonk/src/scalars.rs
+++ b/circuits/plonk/src/scalars.rs
@@ -19,6 +19,7 @@ pub struct ProofEvaluations<Fs> {
     pub sigma2: Fs,
 }
 
+#[derive(Clone, Debug)]
 pub struct RandomOracles<F: Field>
 {
     pub beta: F,

--- a/circuits/plonk/src/wires.rs
+++ b/circuits/plonk/src/wires.rs
@@ -7,7 +7,7 @@ This source file implements Plonk circuit gate wires primitive.
 use algebra::bytes::{FromBytes, ToBytes};
 use std::io::{Read, Result as IoResult, Write};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct GateWires
 {
     pub l: (usize, usize),  // left input wire index and its permutation
@@ -64,17 +64,17 @@ impl GateWires
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum Col {L, R, O}
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Wire
 {
     pub row: usize,         // wire row
     pub col: Col,           // wire column
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Wires
 {
     pub row: usize,         // gate wire row

--- a/circuits/plonk/src/wires.rs
+++ b/circuits/plonk/src/wires.rs
@@ -4,12 +4,45 @@ This source file implements Plonk circuit gate wires primitive.
 
 *****************************************************************************************************************/
 
+use algebra::bytes::{FromBytes, ToBytes};
+use std::io::{Read, Result as IoResult, Write};
+
 #[derive(Clone, Copy)]
 pub struct GateWires
 {
     pub l: (usize, usize),  // left input wire index and its permutation
     pub r: (usize, usize),  // right input wire index and its permutation
     pub o: (usize, usize),  // output wire index and its permutation
+}
+
+impl ToBytes for GateWires {
+    #[inline]
+    fn write<W: Write>(&self, mut w: W) -> IoResult<()> {
+        (self.l.0 as u32).write(&mut w)?;
+        (self.l.1 as u32).write(&mut w)?;
+        (self.r.0 as u32).write(&mut w)?;
+        (self.r.1 as u32).write(&mut w)?;
+        (self.o.0 as u32).write(&mut w)?;
+        (self.o.1 as u32).write(&mut w)?;
+        Ok(())
+    }
+}
+
+impl FromBytes for GateWires {
+    #[inline]
+    fn read<R: Read>(mut r: R) -> IoResult<Self> {
+        let l0 = u32::read(&mut r)? as usize;
+        let l1 = u32::read(&mut r)? as usize;
+        let r0 = u32::read(&mut r)? as usize;
+        let r1 = u32::read(&mut r)? as usize;
+        let o0 = u32::read(&mut r)? as usize;
+        let o1 = u32::read(&mut r)? as usize;
+        Ok(GateWires {
+            l: (l0, l1),
+            r: (r0, r1),
+            o: (o0, o1),
+        })
+    }
 }
 
 impl GateWires

--- a/circuits/plonk/src/wires.rs
+++ b/circuits/plonk/src/wires.rs
@@ -29,3 +29,22 @@ impl GateWires
         }
     }
 }
+
+#[derive(Clone, Copy)]
+pub enum Col {L, R, O}
+
+#[derive(Clone, Copy)]
+pub struct Wire
+{
+    pub row: usize,         // wire row
+    pub col: Col,           // wire column
+}
+
+#[derive(Clone, Copy)]
+pub struct Wires
+{
+    pub row: usize,         // gate wire row
+    pub l: Wire,            // left input wire permutation
+    pub r: Wire,            // right input wire permutation
+    pub o: Wire,            // output input wire permutation
+}

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -63,8 +63,12 @@ impl<C: AffineCurve> PolyComm<C>
                         {
                             let mut points = Vec::new();
                             let mut scalars = Vec::new();
-                            com.iter().zip(elm.iter()).for_each
-                                (|(p, s)| if i < p.unshifted.len() {points.push(p.unshifted[i]); scalars.push(s.into_repr())});
+                            com.iter().zip(elm.iter()).for_each(|(p, s)| {
+                                if i < p.unshifted.len() {
+                                    points.push(p.unshifted[i]);
+                                    scalars.push(s.into_repr())
+                                }
+                            });
                             VariableBaseMSM::multi_scalar_mul(&points, &scalars).into_affine()
                         }
                     ).collect::<Vec<_>>()

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -301,7 +301,7 @@ impl<G: CommitmentCurve> SRS<G> where G::ScalarField : CommitmentField {
             Some(max) =>
             {
                 if plnm.is_zero() {Some(G::zero())}
-                else if max % n == 0 {None}
+                else if max % n == 0 {Some(G::zero())}
                 else
                 {
                     Some(VariableBaseMSM::multi_scalar_mul

--- a/dlog/commitment/src/srs.rs
+++ b/dlog/commitment/src/srs.rs
@@ -86,11 +86,6 @@ impl<G: CommitmentCurve> SRS<G> where G::BaseField : PrimeField, G::ScalarField 
         for x in &self.g {
             G::write(x, &mut writer)?;
         }
-        /*
-        u64::write(&(self.lgr_comm.len() as u64), &mut writer)?;
-        for x in &self.lgr_comm {
-            G::write(&x.unshifted[0], &mut writer)?;
-        } */
         G::write(&self.h, &mut writer)?;
         Ok(())
     }

--- a/dlog/commitment/src/srs.rs
+++ b/dlog/commitment/src/srs.rs
@@ -7,9 +7,8 @@ This source file implements the Marlin structured reference string primitive
 pub use crate::{QnrField, CommitmentField};
 use blake2::{Blake2b, Digest};
 use std::io::{Read, Result as IoResult, Write};
-use algebra::{FromBytes, PrimeField, ToBytes, BigInteger, Zero, One};
-use ff_fft::{Radix2EvaluationDomain as D, Evaluations, EvaluationDomain};
-use crate::commitment::{CommitmentCurve, PolyComm};
+use algebra::{FromBytes, PrimeField, ToBytes, BigInteger};
+use crate::commitment::CommitmentCurve;
 use groupmap::GroupMap;
 
 #[derive(Debug, Clone)]
@@ -47,9 +46,8 @@ impl<G: CommitmentCurve> SRS<G> where G::BaseField : PrimeField, G::ScalarField 
 
     // This function creates SRS instance for circuits up to depth d
     //      depth: maximal depth of SRS string
-    //      public: maximal number of public inputs
     //      size: circuit size
-    pub fn create(depth: usize, public: usize, size: usize) -> Self {
+    pub fn create(depth: usize) -> Self {
         let m = G::Map::setup();
 
         const N : usize = 31;

--- a/dlog/commitment/src/srs.rs
+++ b/dlog/commitment/src/srs.rs
@@ -94,12 +94,6 @@ impl<G: CommitmentCurve> SRS<G> where G::BaseField : PrimeField, G::ScalarField 
         for _ in 0..n {
             g.push(G::read(&mut reader)?);
         }
-        /*
-        let n = u64::read(&mut reader)? as usize;
-        let mut lgr_comm = Vec::with_capacity(n);
-        for _ in 0..n {
-            lgr_comm.push(PolyComm::<G>{shifted: None, unshifted: vec![G::read(&mut reader)?]});
-        } */
 
         let h = G::read(&mut reader)?;
         let (endo_q, endo_r) = endos::<G>();

--- a/dlog/marlin/src/index.rs
+++ b/dlog/marlin/src/index.rs
@@ -37,7 +37,7 @@ pub enum SRSSpec <'a, G: CommitmentCurve>{
 
 impl<'a, G: CommitmentCurve> SRSValue<'a, G> where G::BaseField : PrimeField, G::ScalarField : CommitmentField {
     pub fn generate(size: usize) -> SRS<G> {
-        SRS::<G>::create(size, 0, 0)
+        SRS::<G>::create(size)
     }
 
     pub fn create<'b>(size: usize, spec : SRSSpec<'a, G>) -> SRSValue<'a, G>{

--- a/dlog/plonk/src/index.rs
+++ b/dlog/plonk/src/index.rs
@@ -98,6 +98,9 @@ pub struct VerifierIndex<'a, G: CommitmentCurve>
     // random oracle argument parameters
     pub fr_sponge_params: ArithmeticSpongeParams<Fr<G>>,
     pub fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
+
+    // Endo from the other curve
+    pub endo: Fr<G>
 }
 
 impl<'a, G: CommitmentCurve> Index<'a, G> where G::BaseField: PrimeField, G::ScalarField : CommitmentField
@@ -132,6 +135,7 @@ impl<'a, G: CommitmentCurve> Index<'a, G> where G::BaseField: PrimeField, G::Sca
 
             fr_sponge_params: self.cs.fr_sponge_params.clone(),
             fq_sponge_params: self.fq_sponge_params.clone(),
+            endo: self.cs.endo,
             max_poly_size: self.max_poly_size,
             max_quot_size: self.max_quot_size,
             srs,

--- a/dlog/plonk/src/index.rs
+++ b/dlog/plonk/src/index.rs
@@ -145,6 +145,7 @@ impl<'a, G: CommitmentCurve> Index<'a, G> where G::BaseField: PrimeField, G::Sca
     (
         mut cs: ConstraintSystem<Fr<G>>,
         fq_sponge_params: ArithmeticSpongeParams<Fq<G>>,
+        endo_q: Fr<G>,
         srs : SRSSpec<'a, G>
     ) -> Self
     {
@@ -154,7 +155,7 @@ impl<'a, G: CommitmentCurve> Index<'a, G> where G::BaseField: PrimeField, G::Sca
         {
             assert!(max_poly_size >= cs.domain.d1.size as usize, "polynomial segment size has to be not smaller that that of the circuit!");
         }
-        cs.endo = srs.get_ref().endo_r;
+        cs.endo = endo_q;
         Index
         {
             max_quot_size: 5 * (cs.domain.d1.size as usize + 1),

--- a/dlog/plonk/src/plonk_sponge.rs
+++ b/dlog/plonk/src/plonk_sponge.rs
@@ -39,10 +39,10 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr, SC> {
             &e.r,
             &e.o,
             &e.z,
-            &e.t,
             &e.f,
             &e.sigma1,
             &e.sigma2,
+            &e.t,
         ];
 
         for p in &points {

--- a/dlog/plonk/src/plonk_sponge.rs
+++ b/dlog/plonk/src/plonk_sponge.rs
@@ -36,7 +36,7 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr, SC> {
 
         let points = [
             &e.l,
-            &e.t,
+            &e.r,
             &e.o,
             &e.z,
             &e.t,

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -175,7 +175,8 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
 
         // absorb the polycommitments into the argument and sample zeta
         fq_sponge.absorb_g(&t_comm.unshifted);
-        oracles.zeta = ScalarChallenge(fq_sponge.challenge()).to_field(&index.srs.get_ref().endo_r);
+        oracles.zeta_chal = ScalarChallenge(fq_sponge.challenge());
+        oracles.zeta = oracles.zeta_chal.to_field(&index.srs.get_ref().endo_r);
 
         // evaluate the polynomials
 
@@ -241,8 +242,10 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         for i in 0..2 {fr_sponge.absorb_evaluations(&p_eval[i], &evals[i])}
 
         // query opening scaler challenges
-        oracles.v = fr_sponge.challenge().to_field(&index.srs.get_ref().endo_r);
-        oracles.u = fr_sponge.challenge().to_field(&index.srs.get_ref().endo_r);
+        oracles.v_chal = fr_sponge.challenge();
+        oracles.v = oracles.v_chal.to_field(&index.srs.get_ref().endo_r);
+        oracles.u_chal = fr_sponge.challenge();
+        oracles.u = oracles.u_chal.to_field(&index.srs.get_ref().endo_r);
 
         // construct the proof
         // --------------------------------------------------------------------

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -12,7 +12,6 @@ use plonk_circuits::scalars::{ProofEvaluations, RandomOracles};
 use crate::plonk_sponge::{FrSponge};
 pub use super::index::Index;
 use rand_core::OsRng;
-use std::time::Instant;
 
 type Fr<G> = <G as AffineCurve>::ScalarField;
 type Fq<G> = <G as AffineCurve>::BaseField;
@@ -58,7 +57,6 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField, 
     )
     -> Result<Self, ProofError>
     {
-        let tm = Instant::now();
         let n = index.cs.domain.d1.size as usize;
         if witness.len() != 3*n {return Err(ProofError::WitnessCsInconsistent)}
 

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -179,10 +179,14 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         let dummy = G::of_coordinates(Fq::<G>::zero(), Fq::<G>::zero());
         fq_sponge.absorb_g(&t_comm.unshifted);
         fq_sponge.absorb_g(&vec![dummy; max_t_size - t_comm.unshifted.len()]);
-        match t_comm.shifted {
-            None => fq_sponge.absorb_g(&[dummy]),
-            Some(g) => fq_sponge.absorb_g(&[g]),
-        }
+        {
+            let s = t_comm.shifted.unwrap();
+            if s.is_zero() {
+                fq_sponge.absorb_g(&[dummy])
+            } else {
+                fq_sponge.absorb_g(&[s])
+            }
+        };
 
         oracles.zeta_chal = ScalarChallenge(fq_sponge.challenge());
         oracles.zeta = oracles.zeta_chal.to_field(&index.srs.get_ref().endo_r);

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -257,13 +257,13 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         polynoms.extend(
             vec!
             [
+                (&p, None),
                 (&l, None),
                 (&r, None),
                 (&o, None),
                 (&z, None),
                 (&t, Some(index.max_quot_size)),
                 (&f, None),
-                (&p, None),
                 (&index.cs.sigmam[0], None),
                 (&index.cs.sigmam[1], None),
             ]);

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -175,6 +175,7 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
 
         // absorb the polycommitments into the argument and sample zeta
         fq_sponge.absorb_g(&t_comm.unshifted);
+        fq_sponge.absorb_g(&[t_comm.shifted.unwrap()]);
         oracles.zeta_chal = ScalarChallenge(fq_sponge.challenge());
         oracles.zeta = oracles.zeta_chal.to_field(&index.srs.get_ref().endo_r);
 

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -60,7 +60,7 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField, 
     {
         let tm = Instant::now();
         let n = index.cs.domain.d1.size as usize;
-        if witness.len() != 3*n || !index.cs.verify(&witness) {return Err(ProofError::WitnessCsInconsistent)}
+        if witness.len() != 3*n {return Err(ProofError::WitnessCsInconsistent)}
 
         let mut oracles = RandomOracles::<Fr<G>>::zero();
 

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -43,10 +43,6 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         let mut oracles = RandomOracles::<Fr<G>>::zero();
         let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
         // absorb the public input, l, r, o polycommitments into the argument
-        { 
-        assert_eq!(p_comm.unshifted.len(), 1);
-            let public_input_comm = p_comm.unshifted[0].to_coordinates().unwrap();
-        println!("oracles public_input_comm {} {}", public_input_comm.0, public_input_comm.1) };
         fq_sponge.absorb_g(&p_comm.unshifted);
         fq_sponge.absorb_g(&self.l_comm.unshifted);
         fq_sponge.absorb_g(&self.r_comm.unshifted);
@@ -243,7 +239,7 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
                 // EC variable base scalar multiplication constraint linearization scalars
                 s.extend(&ConstraintSystem::vbmul_scalars(&evals, &alpha));
                 // group endomorphism optimised variable base scalar multiplication constraint linearization scalars
-                s.extend(&ConstraintSystem::endomul_scalars(&evals, index.srs.get_ref().endo_r, &alpha));
+                s.extend(&ConstraintSystem::endomul_scalars(&evals, index.endo, &alpha));
 
                 let f_comm = PolyComm::multi_scalar_mul(&p, &s);
 
@@ -287,12 +283,13 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
                         (&proof.r_comm, proof.evals.iter().map(|e| &e.r).collect::<Vec<_>>(), None),
                         (&proof.o_comm, proof.evals.iter().map(|e| &e.o).collect::<Vec<_>>(), None),
                         (&proof.z_comm, proof.evals.iter().map(|e| &e.z).collect::<Vec<_>>(), None),
-                        (&proof.t_comm, proof.evals.iter().map(|e| &e.t).collect::<Vec<_>>(), Some(index.max_quot_size)),
 
                         (f_comm, proof.evals.iter().map(|e| &e.f).collect::<Vec<_>>(), None),
 
                         (&index.sigma_comm[0], proof.evals.iter().map(|e| &e.sigma1).collect::<Vec<_>>(), None),
                         (&index.sigma_comm[1], proof.evals.iter().map(|e| &e.sigma2).collect::<Vec<_>>(), None),
+
+                        (&proof.t_comm, proof.evals.iter().map(|e| &e.t).collect::<Vec<_>>(), Some(index.max_quot_size)),
                     ]
                 );
 

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -43,6 +43,10 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         let mut oracles = RandomOracles::<Fr<G>>::zero();
         let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
         // absorb the public input, l, r, o polycommitments into the argument
+        { 
+        assert_eq!(p_comm.unshifted.len(), 1);
+            let public_input_comm = p_comm.unshifted[0].to_coordinates().unwrap();
+        println!("oracles public_input_comm {} {}", public_input_comm.0, public_input_comm.1) };
         fq_sponge.absorb_g(&p_comm.unshifted);
         fq_sponge.absorb_g(&self.l_comm.unshifted);
         fq_sponge.absorb_g(&self.r_comm.unshifted);

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -27,11 +27,8 @@ pub struct CachedValues<Fs> {
 impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
 {
 
-    // This function queries random oracle values from non-interactive
-    // argument context by verifier
-    // This setup is partial; the values `u` and `v` are initialized to zero so
-    // that the evaluations it uses can be cached for use in the verification.
-    pub fn setup_oracles
+    // This function runs random oracle argument
+    pub fn oracles
         <EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>,
          EFrSponge: FrSponge<Fr<G>>,
         >
@@ -39,8 +36,9 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         &self,
         index: &Index<G>,
         p_comm: &PolyComm<G>,
-    ) -> (EFqSponge, RandomOracles<Fr<G>>)
+    ) -> (EFqSponge, Fr<G>, RandomOracles<Fr<G>>, Vec<Fr<G>>, [Vec<Fr<G>>; 2], Fr<G>, Fr<G>)
     {
+        let n = index.domain.size;
         // Run random oracle argument to sample verifier oracles
         let mut oracles = RandomOracles::<Fr<G>>::zero();
         let mut fq_sponge = EFqSponge::new(index.fq_sponge_params.clone());
@@ -58,80 +56,45 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         // absorb the polycommitments into the argument and sample zeta
         fq_sponge.absorb_g(&self.t_comm.unshifted);
         oracles.zeta = ScalarChallenge(fq_sponge.challenge()).to_field(&index.srs.get_ref().endo_r);
+        let digest = fq_sponge.clone().digest();
+        let mut fr_sponge =
+        {
+            let mut s = EFrSponge::new(index.fr_sponge_params.clone());
+            s.absorb(&digest);
+            s
+        };
 
-        (fq_sponge, oracles)
-    }
-
-    pub fn gen_cached_values
-    (
-        index: &Index<G>,
-        oracles: &RandomOracles<Fr<G>>
-    ) -> CachedValues<Fr<G>>
-    {
-        let n = index.domain.size;
+        // prepare some often used values
         let zeta1 = oracles.zeta.pow(&[n]);
         let zetaw = oracles.zeta * &index.domain.group_gen;
         let mut alpha = oracles.alpha;
         let alpha = (0..4).map(|_| {alpha *= &oracles.alpha; alpha}).collect::<Vec<_>>();
 
-        CachedValues {zeta1, zetaw, alpha}
-    }
-
-    pub fn p_eval
-    (
-        &self,
-        index: &Index<G>,
-        oracles: &RandomOracles<Fr<G>>,
-        cached_values: &CachedValues<Fr<G>>,
-    ) -> [Vec<Fr<G>>; 2]
-    {
-        let n = index.domain.size;
-
         // compute Lagrange base evaluation denominators
         let w = (0..self.public.len()).zip(index.domain.elements()).map(|(_,w)| w).collect::<Vec<_>>();
         let mut lagrange = w.iter().map(|w| oracles.zeta - w).collect::<Vec<_>>();
-        (0..self.public.len()).zip(w.iter()).for_each(|(_,w)| lagrange.push(cached_values.zetaw - w));
+        (0..self.public.len()).zip(w.iter()).for_each(|(_,w)| lagrange.push(zetaw - w));
         algebra::fields::batch_inversion::<Fr<G>>(&mut lagrange);
 
         // evaluate public input polynomials
-        // NOTE: this works only in the case when the poly segment size is not smaller than that of the domain
-        if self.public.len() > 0
+        // NOTE: this works only in the case when the poly segment size is not smaller than that of the domain 
+        let p_eval = if self.public.len() > 0
         {[
             vec![(self.public.iter().zip(lagrange.iter()).
                 zip(index.domain.elements()).map(|((p, l), w)| -*l * p * &w).
-                fold(Fr::<G>::zero(), |x, y| x + &y)) * &(cached_values.zeta1 - &Fr::<G>::one()) * &index.domain.size_inv],
+                fold(Fr::<G>::zero(), |x, y| x + &y)) * &(zeta1 - &Fr::<G>::one()) * &index.domain.size_inv],
             vec![(self.public.iter().zip(lagrange[self.public.len()..].iter()).
                 zip(index.domain.elements()).map(|((p, l), w)| -*l * p * &w).
-                fold(Fr::<G>::zero(), |x, y| x + &y)) * &index.domain.size_inv * &(cached_values.zetaw.pow(&[n as u64]) - &Fr::<G>::one())]
+                fold(Fr::<G>::zero(), |x, y| x + &y)) * &index.domain.size_inv * &(zetaw.pow(&[n as u64]) - &Fr::<G>::one())]
         ]}
-        else {[Vec::<Fr<G>>::new(), Vec::<Fr<G>>::new()]}
-    }
-
-    // This function constructs the values `u` and `v` in the random oracle.
-    pub fn finalize_oracles
-        <EFqSponge: Clone + FqSponge<Fq<G>, G, Fr<G>>,
-         EFrSponge: FrSponge<Fr<G>>,
-        >
-    (
-        &self,
-        index: &Index<G>,
-        p_eval: &[Vec<Fr<G>>; 2],
-        fq_sponge: &EFqSponge,
-        oracles: &mut RandomOracles<Fr<G>>,
-    ) -> ()
-    {
-        let mut fr_sponge =
-        {
-            let mut s = EFrSponge::new(index.fr_sponge_params.clone());
-            s.absorb(&fq_sponge.clone().digest());
-            s
-        };
-
+        else {[Vec::<Fr<G>>::new(), Vec::<Fr<G>>::new()]};
         for i in 0..2 {fr_sponge.absorb_evaluations(&p_eval[i], &self.evals[i])}
 
-        // query opening scalar challenges
+        // query opening scaler challenges
         oracles.v = fr_sponge.challenge().to_field(&index.srs.get_ref().endo_r);
         oracles.u = fr_sponge.challenge().to_field(&index.srs.get_ref().endo_r);
+
+        (fq_sponge, digest, oracles, alpha, p_eval, zeta1, zetaw)
     }
 
     // This function verifies the batch of zk-proofs
@@ -158,17 +121,13 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
                 let p_comm = PolyComm::<G>::multi_scalar_mul
                     (&index.srs.get_ref().lgr_comm.iter().map(|l| l).collect(), &proof.public.iter().map(|s| -*s).collect());
 
-                let (mut fq_sponge, mut oracles) = proof.setup_oracles::<EFqSponge, EFrSponge>(index, &p_comm);
-                // prepare some often used values
-                let cached_values = ProverProof::<G>::gen_cached_values(index, &oracles);
-                let p_eval = proof.p_eval(index, &oracles, &cached_values);
-                proof.finalize_oracles::<EFqSponge, EFrSponge>(index, &p_eval, &mut fq_sponge, &mut oracles);
+                let (fq_sponge, _, oracles, alpha, p_eval, zeta1, zetaw) = proof.oracles::<EFqSponge, EFrSponge>(index, &p_comm);
 
-                let ep = [oracles.zeta, cached_values.zetaw];
+                let ep = [oracles.zeta, zetaw];
                 let evlp =
                 [
                     oracles.zeta.pow(&[index.max_poly_size as u64]),
-                    cached_values.zetaw.pow(&[index.max_poly_size as u64])
+                    zetaw.pow(&[index.max_poly_size as u64])
                 ];
 
                 let polys = proof.prev_challenges.iter().map(|(chals, poly)| {
@@ -256,13 +215,13 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
                 // generic constraint/permutation linearization scalars
                 s.extend(&ConstraintSystem::gnrc_scalars(&evals[0]));
                 // poseidon constraint linearization scalars
-                s.extend(&ConstraintSystem::psdn_scalars(&evals, &index.fr_sponge_params, &cached_values.alpha));
+                s.extend(&ConstraintSystem::psdn_scalars(&evals, &index.fr_sponge_params, &alpha));
                 // EC addition constraint linearization scalars
-                s.extend(&ConstraintSystem::ecad_scalars(&evals, &cached_values.alpha));
+                s.extend(&ConstraintSystem::ecad_scalars(&evals, &alpha));
                 // EC variable base scalar multiplication constraint linearization scalars
-                s.extend(&ConstraintSystem::vbmul_scalars(&evals, &cached_values.alpha));
+                s.extend(&ConstraintSystem::vbmul_scalars(&evals, &alpha));
                 // group endomorphism optimised variable base scalar multiplication constraint linearization scalars
-                s.extend(&ConstraintSystem::endomul_scalars(&evals, index.srs.get_ref().endo_r, &cached_values.alpha));
+                s.extend(&ConstraintSystem::endomul_scalars(&evals, index.srs.get_ref().endo_r, &alpha));
 
                 let f_comm = PolyComm::multi_scalar_mul(&p, &s);
 
@@ -274,11 +233,11 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
                     &(evals[0].r + &(oracles.beta * &evals[0].sigma2) + &oracles.gamma) *
                     (evals[0].o + &oracles.gamma) * &evals[1].z * &oracles.alpha)
                     -
-                    evals[0].t * &(cached_values.zeta1 - &Fr::<G>::one()))
+                    evals[0].t * &(zeta1 - &Fr::<G>::one()))
                     *
                     &(oracles.zeta - &Fr::<G>::one())
                 !=
-                    (cached_values.zeta1 - &Fr::<G>::one()) * &cached_values.alpha[0]
+                    (zeta1 - &Fr::<G>::one()) * &alpha[0]
                 {return Err(ProofError::ProofVerification)}
 
                 Ok((p_eval, p_comm, f_comm, fq_sponge, oracles, polys))

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -55,6 +55,7 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         oracles.alpha = fq_sponge.challenge();
         // absorb the polycommitments into the argument and sample zeta
         fq_sponge.absorb_g(&self.t_comm.unshifted);
+        fq_sponge.absorb_g(&[self.t_comm.shifted.unwrap()]);
         oracles.zeta_chal = ScalarChallenge(fq_sponge.challenge());
         oracles.zeta = oracles.zeta_chal.to_field(&index.srs.get_ref().endo_r);
         let digest = fq_sponge.clone().digest();

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -278,7 +278,7 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
                 (
                     vec!
                     [
-                        (&*p_comm, p_eval.iter().map(|e| e).collect::<Vec<_>>(), None),
+                        (p_comm, p_eval.iter().map(|e| e).collect::<Vec<_>>(), None),
                         (&proof.l_comm, proof.evals.iter().map(|e| &e.l).collect::<Vec<_>>(), None),
                         (&proof.r_comm, proof.evals.iter().map(|e| &e.r).collect::<Vec<_>>(), None),
                         (&proof.o_comm, proof.evals.iter().map(|e| &e.o).collect::<Vec<_>>(), None),

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -55,7 +55,8 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         oracles.alpha = fq_sponge.challenge();
         // absorb the polycommitments into the argument and sample zeta
         fq_sponge.absorb_g(&self.t_comm.unshifted);
-        oracles.zeta = ScalarChallenge(fq_sponge.challenge()).to_field(&index.srs.get_ref().endo_r);
+        oracles.zeta_chal = ScalarChallenge(fq_sponge.challenge());
+        oracles.zeta = oracles.zeta_chal.to_field(&index.srs.get_ref().endo_r);
         let digest = fq_sponge.clone().digest();
         let mut fr_sponge =
         {
@@ -91,8 +92,10 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         for i in 0..2 {fr_sponge.absorb_evaluations(&p_eval[i], &self.evals[i])}
 
         // query opening scaler challenges
-        oracles.v = fr_sponge.challenge().to_field(&index.srs.get_ref().endo_r);
-        oracles.u = fr_sponge.challenge().to_field(&index.srs.get_ref().endo_r);
+        oracles.v_chal = fr_sponge.challenge();
+        oracles.v = oracles.v_chal.to_field(&index.srs.get_ref().endo_r);
+        oracles.u_chal = fr_sponge.challenge();
+        oracles.u = oracles.u_chal.to_field(&index.srs.get_ref().endo_r);
 
         (fq_sponge, digest, oracles, alpha, p_eval, zeta1, zetaw)
     }
@@ -119,14 +122,8 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
             |proof|
             {
                 // commit to public input polynomial
-<<<<<<< Updated upstream
                 let p_comm = PolyComm::<G>::multi_scalar_mul
-                    (&index.srs.get_ref().lgr_comm.iter().map(|l| l).collect(), &proof.public.iter().map(|s| -*s).collect());
-=======
-                *p_comm = PolyComm::<G>::multi_scalar_mul
-                    (&lgr_comm.iter().take(proof.public.len()).map(|l| l).collect(),
-                    &proof.public.iter().map(|s| -*s).collect());
->>>>>>> Stashed changes
+                    (& lgr_comm.iter().take(proof.public.len()).map(|l| l).collect(), &proof.public.iter().map(|s| -*s).collect());
 
                 let (fq_sponge, _, oracles, alpha, p_eval, zeta1, zetaw) = proof.oracles::<EFqSponge, EFrSponge>(index, &p_comm);
 

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -108,6 +108,7 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
     (
         group_map: &G::Map,
         proofs: &Vec<ProverProof<G>>,
+        lgr_comm: &Vec<PolyComm<G>>,
         index: &Index<G>,
     ) -> Result<bool, ProofError>
     {
@@ -118,8 +119,14 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
             |proof|
             {
                 // commit to public input polynomial
+<<<<<<< Updated upstream
                 let p_comm = PolyComm::<G>::multi_scalar_mul
                     (&index.srs.get_ref().lgr_comm.iter().map(|l| l).collect(), &proof.public.iter().map(|s| -*s).collect());
+=======
+                *p_comm = PolyComm::<G>::multi_scalar_mul
+                    (&lgr_comm.iter().take(proof.public.len()).map(|l| l).collect(),
+                    &proof.public.iter().map(|s| -*s).collect());
+>>>>>>> Stashed changes
 
                 let (fq_sponge, _, oracles, alpha, p_eval, zeta1, zetaw) = proof.oracles::<EFqSponge, EFrSponge>(index, &p_comm);
 
@@ -260,6 +267,7 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
                 (
                     vec!
                     [
+                        (&*p_comm, p_eval.iter().map(|e| e).collect::<Vec<_>>(), None),
                         (&proof.l_comm, proof.evals.iter().map(|e| &e.l).collect::<Vec<_>>(), None),
                         (&proof.r_comm, proof.evals.iter().map(|e| &e.r).collect::<Vec<_>>(), None),
                         (&proof.o_comm, proof.evals.iter().map(|e| &e.o).collect::<Vec<_>>(), None),
@@ -267,7 +275,6 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
                         (&proof.t_comm, proof.evals.iter().map(|e| &e.t).collect::<Vec<_>>(), Some(index.max_quot_size)),
 
                         (f_comm, proof.evals.iter().map(|e| &e.f).collect::<Vec<_>>(), None),
-                        (p_comm, p_eval.iter().map(|e| e).collect::<Vec<_>>(), None),
 
                         (&index.sigma_comm[0], proof.evals.iter().map(|e| &e.sigma1).collect::<Vec<_>>(), None),
                         (&index.sigma_comm[1], proof.evals.iter().map(|e| &e.sigma2).collect::<Vec<_>>(), None),

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -59,10 +59,14 @@ impl<G: CommitmentCurve> ProverProof<G> where G::ScalarField : CommitmentField
         let dummy = G::of_coordinates(Fq::<G>::zero(), Fq::<G>::zero());
         fq_sponge.absorb_g(&self.t_comm.unshifted);
         fq_sponge.absorb_g(&vec![dummy; max_t_size - self.t_comm.unshifted.len()]);
-        match self.t_comm.shifted {
-            None => fq_sponge.absorb_g(&[dummy]),
-            Some(g) => fq_sponge.absorb_g(&[g]),
-        }
+        {
+            let s = self.t_comm.shifted.unwrap();
+            if s.is_zero() {
+                fq_sponge.absorb_g(&[dummy])
+            } else {
+                fq_sponge.absorb_g(&[s])
+            }
+        };
 
         oracles.zeta_chal = ScalarChallenge(fq_sponge.challenge());
         oracles.zeta = oracles.zeta_chal.to_field(&index.srs.get_ref().endo_r);

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -10,3 +10,4 @@ path = "src/lib.rs"
 algebra = { path = "../../zexe/algebra", features = [ "parallel", "bn_382", "tweedle", "asm" ] }
 ff-fft = { path = "../../zexe/ff-fft" }
 rand = "0.7.3"
+rayon = { version = "1" }

--- a/oracle/src/poseidon.rs
+++ b/oracle/src/poseidon.rs
@@ -57,9 +57,12 @@ pub trait Sponge<Input, Digest> {
     fn squeeze(&mut self, params: &Self::Params) -> Digest;
 }
 
-// TODO: Specialize to 5
 pub fn sbox<F : Field, SC: SpongeConstants>(x: F) -> F {
-    x.pow([SC::SPONGE_BOX as u64])
+    let mut res = x;
+    res.square_in_place();
+    res.square_in_place();
+    res *= x;
+    res
 }
 
 #[derive(Clone, Debug)]

--- a/oracle/src/poseidon.rs
+++ b/oracle/src/poseidon.rs
@@ -182,13 +182,8 @@ impl<F: Field, SC: SpongeConstants> Sponge<F, F> for ArithmeticSponge<F, SC> {
     }
 
     fn absorb(&mut self, params: &ArithmeticSpongeParams<F>, x: &[F]) {
-        println!("Rabsorb state pre");
-        for x in self.state.iter() {
-            println!("{}", x);
-        }
         for x in x.iter()
         {
-            println!("Rabsorb {}", x);
             match self.sponge_state {
                 SpongeState::Absorbed(n) => {
                     if n == self.rate {
@@ -206,18 +201,9 @@ impl<F: Field, SC: SpongeConstants> Sponge<F, F> for ArithmeticSponge<F, SC> {
                 }
             }
         }
-        println!("Rabsorb state post");
-        for x in self.state.iter() {
-            println!("{}", x);
-        }
     }
 
     fn squeeze(&mut self, params: &ArithmeticSpongeParams<F>) -> F {
-        println!("Rsqueeze state pre");
-        for x in self.state.iter() {
-            println!("{}", x);
-        }
-        let res = 
         match self.sponge_state {
             SpongeState::Squeezed(n) => {
                 if n == self.rate {
@@ -234,12 +220,6 @@ impl<F: Field, SC: SpongeConstants> Sponge<F, F> for ArithmeticSponge<F, SC> {
                 self.sponge_state = SpongeState::Squeezed(1);
                 self.state[0]
             }
-        };
-        println!("Rsqueeze {}", res);
-        println!("Rsqueeze state post");
-        for x in self.state.iter() {
-            println!("{}", x);
         }
-        res
     }
 }


### PR DESCRIPTION
This PR
- adds some functions for serialization
- changes the order of polynomial commitments in the batch to match the verifier circuits
- does batch plonk proof verification
- exposes a method to generate the plonk constraint system shifts (r, o)
- stores the underlying scalar challenge values for zeta, v, and u