### PR TITLE
[step 5] zexe -> arkworks

### DIFF
--- a/circuits/plonk-5-wires/Cargo.toml
+++ b/circuits/plonk-5-wires/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies]
-algebra = { path = "../../zexe/algebra", features = [ "parallel", "asm" ] }
-ff-fft = { path = "../../zexe/ff-fft", features = [ "parallel"] }
+ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ocaml = { version = "0.18.1", optional = true }
 oracle = { path = "../../oracle" }
 rand_core = { version = "0.5" }

--- a/circuits/plonk-5-wires/Cargo.toml
+++ b/circuits/plonk-5-wires/Cargo.toml
@@ -8,6 +8,7 @@ path = "src/lib.rs"
 
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
+ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 ocaml = { version = "0.18.1", optional = true }
 oracle = { path = "../../oracle" }
 rand_core = { version = "0.5" }

--- a/circuits/plonk-5-wires/src/constraints.rs
+++ b/circuits/plonk-5-wires/src/constraints.rs
@@ -8,9 +8,10 @@ pub use super::domains::EvaluationDomains;
 pub use super::gate::{CircuitGate, GateType};
 pub use super::polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts};
 pub use super::wires::{Wire, COLUMNS, WIRES};
-use ark_ff::{FftField, SquareRootField};
+use ark_ff::{FftField, SquareRootField, Zero};
 use ark_poly::{
-    DensePolynomial as DP, EvaluationDomain, Evaluations as E, Radix2EvaluationDomain as D,
+    univariate::DensePolynomial as DP, EvaluationDomain, Evaluations as E,
+    Radix2EvaluationDomain as D, UVPolynomial,
 };
 use array_init::array_init;
 use blake2::{Blake2b, Digest};

--- a/circuits/plonk-5-wires/src/constraints.rs
+++ b/circuits/plonk-5-wires/src/constraints.rs
@@ -8,12 +8,12 @@ pub use super::domains::EvaluationDomains;
 pub use super::gate::{CircuitGate, GateType};
 pub use super::polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts};
 pub use super::wires::{Wire, COLUMNS, WIRES};
-use algebra::{FftField, SquareRootField};
-use array_init::array_init;
-use blake2::{Blake2b, Digest};
-use ff_fft::{
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{
     DensePolynomial as DP, EvaluationDomain, Evaluations as E, Radix2EvaluationDomain as D,
 };
+use array_init::array_init;
+use blake2::{Blake2b, Digest};
 use oracle::poseidon::ArithmeticSpongeParams;
 use oracle::utils::EvalUtils;
 

--- a/circuits/plonk-5-wires/src/domains.rs
+++ b/circuits/plonk-5-wires/src/domains.rs
@@ -1,5 +1,5 @@
-use algebra::FftField;
-use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as D};
+use ark_ff::FftField;
+use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
 
 #[derive(Debug, Clone, Copy)]
 pub struct EvaluationDomains<F: FftField> {

--- a/circuits/plonk-5-wires/src/gate.rs
+++ b/circuits/plonk-5-wires/src/gate.rs
@@ -5,8 +5,7 @@ This source file implements Plonk constraint gate primitive.
 *****************************************************************************************************************/
 
 pub use super::{constraints::ConstraintSystem, wires::*};
-use algebra::bytes::{FromBytes, ToBytes};
-use algebra::FftField;
+use ark_ff::{FftField, FromBytes, ToBytes};
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 

--- a/circuits/plonk-5-wires/src/gates/addition.rs
+++ b/circuits/plonk-5-wires/src/gates/addition.rs
@@ -31,7 +31,7 @@ This source file implements non-special point (with distinct abscissas) Weierstr
 
 use crate::gate::{CircuitGate, GateType};
 use crate::wires::{GateWires, COLUMNS};
-use algebra::FftField;
+use ark_ff::FftField;
 use array_init::array_init;
 
 impl<F: FftField> CircuitGate<F> {

--- a/circuits/plonk-5-wires/src/gates/double.rs
+++ b/circuits/plonk-5-wires/src/gates/double.rs
@@ -36,7 +36,7 @@ The constraints above are derived from the following EC Affine arithmetic equati
 
 use crate::gate::{CircuitGate, GateType};
 use crate::wires::{GateWires, COLUMNS};
-use algebra::FftField;
+use ark_ff::FftField;
 use array_init::array_init;
 
 impl<F: FftField> CircuitGate<F> {

--- a/circuits/plonk-5-wires/src/gates/endosclmul.rs
+++ b/circuits/plonk-5-wires/src/gates/endosclmul.rs
@@ -57,7 +57,7 @@ use crate::{
     constraints::ConstraintSystem,
     wires::{GateWires, COLUMNS},
 };
-use algebra::FftField;
+use ark_ff::FftField;
 use array_init::array_init;
 
 impl<F: FftField> CircuitGate<F> {

--- a/circuits/plonk-5-wires/src/gates/generic.rs
+++ b/circuits/plonk-5-wires/src/gates/generic.rs
@@ -6,7 +6,7 @@ This source file implements Plonk generic constraint gate primitive.
 
 use crate::gate::{CircuitGate, GateType};
 use crate::wires::{GateWires, COLUMNS};
-use algebra::FftField;
+use ark_ff::FftField;
 use array_init::array_init;
 
 impl<F: FftField> CircuitGate<F> {

--- a/circuits/plonk-5-wires/src/gates/packing.rs
+++ b/circuits/plonk-5-wires/src/gates/packing.rs
@@ -12,7 +12,7 @@ PACK gate constraints
 
 use crate::gate::{CircuitGate, GateType};
 use crate::wires::{GateWires, COLUMNS};
-use algebra::FftField;
+use ark_ff::FftField;
 use array_init::array_init;
 
 impl<F: FftField> CircuitGate<F> {

--- a/circuits/plonk-5-wires/src/gates/poseidon.rs
+++ b/circuits/plonk-5-wires/src/gates/poseidon.rs
@@ -14,7 +14,7 @@ use crate::{
     wires::GateWires,
     wires::{COLUMNS, WIRES},
 };
-use algebra::FftField;
+use ark_ff::FftField;
 use array_init::array_init;
 use oracle::poseidon::{sbox, PlonkSpongeConstants5W};
 

--- a/circuits/plonk-5-wires/src/gates/varbasemul.rs
+++ b/circuits/plonk-5-wires/src/gates/varbasemul.rs
@@ -61,7 +61,7 @@ The constraints above are derived from the following EC Affine arithmetic equati
 
 use crate::gate::{CircuitGate, GateType};
 use crate::wires::{GateWires, COLUMNS};
-use algebra::FftField;
+use ark_ff::FftField;
 use array_init::array_init;
 
 impl<F: FftField> CircuitGate<F> {

--- a/circuits/plonk-5-wires/src/gates/varbasemulpck.rs
+++ b/circuits/plonk-5-wires/src/gates/varbasemulpck.rs
@@ -69,7 +69,7 @@ The constraints above are derived from the following EC Affine arithmetic equati
 
 use crate::gate::{CircuitGate, GateType};
 use crate::wires::{GateWires, COLUMNS};
-use algebra::FftField;
+use ark_ff::FftField;
 use array_init::array_init;
 
 impl<F: FftField> CircuitGate<F> {

--- a/circuits/plonk-5-wires/src/polynomial.rs
+++ b/circuits/plonk-5-wires/src/polynomial.rs
@@ -5,8 +5,8 @@ This source file implements Plonk prover polynomials primitive.
 *****************************************************************************************************************/
 
 pub use super::wires::COLUMNS;
-use algebra::FftField;
-use ff_fft::{Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::FftField;
+use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
 
 #[derive(Clone)]
 pub struct WitnessEvals<F: FftField> {

--- a/circuits/plonk-5-wires/src/polynomials/addition.rs
+++ b/circuits/plonk-5-wires/src/polynomials/addition.rs
@@ -33,8 +33,8 @@ This source file implements non-special point Weierstrass curve addition constra
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/addition.rs
+++ b/circuits/plonk-5-wires/src/polynomials/addition.rs
@@ -33,8 +33,8 @@ This source file implements non-special point Weierstrass curve addition constra
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/double.rs
+++ b/circuits/plonk-5-wires/src/polynomials/double.rs
@@ -37,8 +37,8 @@ The constraints above are derived from the following EC Affine arithmetic equati
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/double.rs
+++ b/circuits/plonk-5-wires/src/polynomials/double.rs
@@ -37,8 +37,8 @@ The constraints above are derived from the following EC Affine arithmetic equati
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/endosclmul.rs
+++ b/circuits/plonk-5-wires/src/polynomials/endosclmul.rs
@@ -55,8 +55,8 @@ The constraints above are derived from the following EC Affine arithmetic equati
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/endosclmul.rs
+++ b/circuits/plonk-5-wires/src/polynomials/endosclmul.rs
@@ -55,8 +55,8 @@ The constraints above are derived from the following EC Affine arithmetic equati
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/generic.rs
+++ b/circuits/plonk-5-wires/src/polynomials/generic.rs
@@ -7,8 +7,8 @@ This source file implements generic constraint polynomials.
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::PolyUtils;
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/generic.rs
+++ b/circuits/plonk-5-wires/src/polynomials/generic.rs
@@ -7,8 +7,8 @@ This source file implements generic constraint polynomials.
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::PolyUtils;
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/packing.rs
+++ b/circuits/plonk-5-wires/src/polynomials/packing.rs
@@ -13,8 +13,8 @@ PACK gate constraints
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/packing.rs
+++ b/circuits/plonk-5-wires/src/polynomials/packing.rs
@@ -13,8 +13,8 @@ PACK gate constraints
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/permutation.rs
+++ b/circuits/plonk-5-wires/src/polynomials/permutation.rs
@@ -8,8 +8,8 @@ use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::{ProofEvaluations, RandomOracles};
 use crate::wires::COLUMNS;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DenseOrSparsePolynomial, DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DenseOrSparsePolynomial, DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::{
     rndoracle::ProofError,
     utils::{EvalUtils, PolyUtils},

--- a/circuits/plonk-5-wires/src/polynomials/permutation.rs
+++ b/circuits/plonk-5-wires/src/polynomials/permutation.rs
@@ -8,8 +8,11 @@ use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::{ProofEvaluations, RandomOracles};
 use crate::wires::COLUMNS;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DenseOrSparsePolynomial, DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{
+    univariate::{DenseOrSparsePolynomial, DensePolynomial},
+    Evaluations, Polynomial, Radix2EvaluationDomain as D, UVPolynomial,
+};
 use oracle::{
     rndoracle::ProofError,
     utils::{EvalUtils, PolyUtils},
@@ -80,7 +83,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
         self.sigmam[COLUMNS - 1].scale(Self::perm_scalars(
             e,
             oracles,
-            self.zkpm.evaluate(oracles.zeta),
+            self.zkpm.evaluate(&oracles.zeta),
         ))
     }
 

--- a/circuits/plonk-5-wires/src/polynomials/poseidon.rs
+++ b/circuits/plonk-5-wires/src/polynomials/poseidon.rs
@@ -8,9 +8,9 @@ use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
 use crate::wires::COLUMNS;
-use ark_ff::{FftField, SquareRootField};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use array_init::array_init;
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::{
     poseidon::ArithmeticSpongeParams,
     poseidon::{sbox, PlonkSpongeConstants5W},

--- a/circuits/plonk-5-wires/src/polynomials/poseidon.rs
+++ b/circuits/plonk-5-wires/src/polynomials/poseidon.rs
@@ -8,9 +8,9 @@ use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
 use crate::wires::COLUMNS;
-use algebra::{FftField, SquareRootField};
+use ark_ff::{FftField, SquareRootField};
 use array_init::array_init;
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::{
     poseidon::ArithmeticSpongeParams,
     poseidon::{sbox, PlonkSpongeConstants5W},

--- a/circuits/plonk-5-wires/src/polynomials/varbasemul.rs
+++ b/circuits/plonk-5-wires/src/polynomials/varbasemul.rs
@@ -62,8 +62,8 @@ The constraints above are derived from the following EC Affine arithmetic equati
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/varbasemul.rs
+++ b/circuits/plonk-5-wires/src/polynomials/varbasemul.rs
@@ -62,8 +62,8 @@ The constraints above are derived from the following EC Affine arithmetic equati
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/varbasemulpck.rs
+++ b/circuits/plonk-5-wires/src/polynomials/varbasemulpck.rs
@@ -71,8 +71,8 @@ The constraints above are derived from the following EC Affine arithmetic equati
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/polynomials/varbasemulpck.rs
+++ b/circuits/plonk-5-wires/src/polynomials/varbasemulpck.rs
@@ -71,8 +71,8 @@ The constraints above are derived from the following EC Affine arithmetic equati
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk-5-wires/src/scalars.rs
+++ b/circuits/plonk-5-wires/src/scalars.rs
@@ -5,9 +5,9 @@ This source file implements Plonk prover polynomial evaluations primitive.
 *****************************************************************************************************************/
 
 pub use super::wires::COLUMNS;
-use algebra::{FftField, Field};
+use ark_ff::{FftField, Field};
 use array_init::array_init;
-use ff_fft::DensePolynomial;
+use ark_poly::DensePolynomial;
 use oracle::{sponge::ScalarChallenge, utils::PolyUtils};
 
 #[derive(Clone)]

--- a/circuits/plonk-5-wires/src/scalars.rs
+++ b/circuits/plonk-5-wires/src/scalars.rs
@@ -6,8 +6,8 @@ This source file implements Plonk prover polynomial evaluations primitive.
 
 pub use super::wires::COLUMNS;
 use ark_ff::{FftField, Field};
+use ark_poly::univariate::DensePolynomial;
 use array_init::array_init;
-use ark_poly::DensePolynomial;
 use oracle::{sponge::ScalarChallenge, utils::PolyUtils};
 
 #[derive(Clone)]

--- a/circuits/plonk-5-wires/src/wires.rs
+++ b/circuits/plonk-5-wires/src/wires.rs
@@ -4,7 +4,7 @@ This source file implements Plonk circuit gate wires primitive.
 
 *****************************************************************************************************************/
 
-use algebra::bytes::{FromBytes, ToBytes};
+use ark_ff::bytes::{FromBytes, ToBytes};
 use std::io::{Read, Result as IoResult, Write};
 
 pub const COLUMNS: usize = 5;

--- a/circuits/plonk/Cargo.toml
+++ b/circuits/plonk/Cargo.toml
@@ -7,9 +7,8 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies]
-algebra = { path = "../../zexe/algebra", features = [ "parallel", "asm" ] }
+ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 mina-curves = { path = "../../curves" }
-ff-fft = { path = "../../zexe/ff-fft", features = [ "parallel"] }
 ocaml = { version = "0.18.1", optional = true }
 oracle = { path = "../../oracle" }
 rand_core = { version = "0.5" }

--- a/circuits/plonk/Cargo.toml
+++ b/circuits/plonk/Cargo.toml
@@ -8,6 +8,7 @@ path = "src/lib.rs"
 
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
+ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 mina-curves = { path = "../../curves" }
 ocaml = { version = "0.18.1", optional = true }
 oracle = { path = "../../oracle" }

--- a/circuits/plonk/src/constraints.rs
+++ b/circuits/plonk/src/constraints.rs
@@ -8,10 +8,10 @@ pub use super::domains::EvaluationDomains;
 pub use super::gate::{CircuitGate, GateType};
 pub use super::polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts};
 pub use super::wires::GateWires;
-use algebra::{FftField, SquareRootField};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
 use array_init::array_init;
 use blake2::{Blake2b, Digest};
-use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
 use oracle::poseidon::{ArithmeticSpongeParams, PlonkSpongeConstants, SpongeConstants};
 use oracle::utils::EvalUtils;
 

--- a/circuits/plonk/src/constraints.rs
+++ b/circuits/plonk/src/constraints.rs
@@ -9,7 +9,9 @@ pub use super::gate::{CircuitGate, GateType};
 pub use super::polynomial::{WitnessEvals, WitnessOverDomains, WitnessShifts};
 pub use super::wires::GateWires;
 use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{
+    univariate::DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as D,
+};
 use array_init::array_init;
 use blake2::{Blake2b, Digest};
 use oracle::poseidon::{ArithmeticSpongeParams, PlonkSpongeConstants, SpongeConstants};

--- a/circuits/plonk/src/domains.rs
+++ b/circuits/plonk/src/domains.rs
@@ -1,5 +1,5 @@
-use algebra::FftField;
-use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as D};
+use ark_ff::FftField;
+use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as D};
 
 #[derive(Debug, Clone, Copy)]
 pub struct EvaluationDomains<F: FftField> {

--- a/circuits/plonk/src/gate.rs
+++ b/circuits/plonk/src/gate.rs
@@ -5,8 +5,8 @@ This source file implements Plonk constraint gate primitive.
 *****************************************************************************************************************/
 
 pub use super::{constraints::ConstraintSystem, wires::*};
-use algebra::bytes::{FromBytes, ToBytes};
-use algebra::FftField;
+use ark_ff::bytes::{FromBytes, ToBytes};
+use ark_ff::FftField;
 use num_traits::cast::{FromPrimitive, ToPrimitive};
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 

--- a/circuits/plonk/src/gates/addition.rs
+++ b/circuits/plonk/src/gates/addition.rs
@@ -26,7 +26,7 @@ l=y1, r=y2, o=y3, l_next=x1, r_next=x2, o_next=x3:
 
 use crate::gate::{CircuitGate, GateType};
 use crate::wires::GateWires;
-use algebra::FftField;
+use ark_ff::FftField;
 
 impl<F: FftField> CircuitGate<F> {
     pub fn create_add(wires: &[GateWires; 2]) -> Vec<Self> {

--- a/circuits/plonk/src/gates/endosclmul.rs
+++ b/circuits/plonk/src/gates/endosclmul.rs
@@ -10,7 +10,7 @@ https://github.com/o1-labs/marlin/issues/41
 
 use crate::gate::{CircuitGate, GateType};
 use crate::{constraints::ConstraintSystem, wires::GateWires};
-use algebra::FftField;
+use ark_ff::FftField;
 
 impl<F: FftField> CircuitGate<F> {
     pub fn create_endomul(wires: &[GateWires; 4]) -> Vec<Self> {

--- a/circuits/plonk/src/gates/generic.rs
+++ b/circuits/plonk/src/gates/generic.rs
@@ -14,7 +14,7 @@ Constraint vector format:
 
 use crate::gate::{CircuitGate, GateType};
 use crate::wires::GateWires;
-use algebra::FftField;
+use ark_ff::FftField;
 
 impl<F: FftField> CircuitGate<F> {
     pub fn create_generic(wires: GateWires, ql: F, qr: F, qo: F, qm: F, qc: F) -> Self {

--- a/circuits/plonk/src/gates/poseidon.rs
+++ b/circuits/plonk/src/gates/poseidon.rs
@@ -10,7 +10,7 @@ Constraint vector format:
 
 use crate::gate::{CircuitGate, GateType};
 use crate::{constraints::ConstraintSystem, wires::GateWires};
-use algebra::FftField;
+use ark_ff::FftField;
 use oracle::poseidon::{sbox, PlonkSpongeConstants, SpongeConstants};
 
 impl<F: FftField> CircuitGate<F> {

--- a/circuits/plonk/src/gates/varbasemul.rs
+++ b/circuits/plonk/src/gates/varbasemul.rs
@@ -41,7 +41,7 @@ Gate 1
 
 use crate::gate::{CircuitGate, GateType};
 use crate::wires::GateWires;
-use algebra::FftField;
+use ark_ff::FftField;
 
 impl<F: FftField> CircuitGate<F> {
     pub fn create_vbmul(wires: &[GateWires; 3]) -> Vec<Self> {

--- a/circuits/plonk/src/polynomial.rs
+++ b/circuits/plonk/src/polynomial.rs
@@ -4,8 +4,8 @@ This source file implements Plonk prover polynomials primitive.
 
 *****************************************************************************************************************/
 
-use algebra::FftField;
-use ff_fft::{Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::FftField;
+use ark_poly::{Evaluations, Radix2EvaluationDomain as D};
 
 #[derive(Clone)]
 pub struct WitnessEvals<F: FftField> {

--- a/circuits/plonk/src/polynomials/addition.rs
+++ b/circuits/plonk/src/polynomials/addition.rs
@@ -25,8 +25,8 @@ Constraint equations on wires l, r, o, l_next, r_next, o_next where
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk/src/polynomials/addition.rs
+++ b/circuits/plonk/src/polynomials/addition.rs
@@ -25,8 +25,8 @@ Constraint equations on wires l, r, o, l_next, r_next, o_next where
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk/src/polynomials/endosclmul.rs
+++ b/circuits/plonk/src/polynomials/endosclmul.rs
@@ -8,8 +8,8 @@ scalar multiplication custom Plonk polynomials.
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk/src/polynomials/endosclmul.rs
+++ b/circuits/plonk/src/polynomials/endosclmul.rs
@@ -8,8 +8,8 @@ scalar multiplication custom Plonk polynomials.
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk/src/polynomials/generic.rs
+++ b/circuits/plonk/src/polynomials/generic.rs
@@ -8,7 +8,7 @@ use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
 use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::PolyUtils;
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk/src/polynomials/generic.rs
+++ b/circuits/plonk/src/polynomials/generic.rs
@@ -7,8 +7,8 @@ This source file implements generic constraint polynomials.
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::PolyUtils;
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk/src/polynomials/permutation.rs
+++ b/circuits/plonk/src/polynomials/permutation.rs
@@ -8,7 +8,7 @@ use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::{ProofEvaluations, RandomOracles};
 use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {
@@ -63,7 +63,7 @@ impl<F: FftField + SquareRootField> ConstraintSystem<F> {
     ) -> Vec<F> {
         let bz = oracles.beta * &oracles.zeta;
         let mut denominator = [oracles.zeta - &F::one(), oracles.zeta - &w];
-        algebra::fields::batch_inversion::<F>(&mut denominator);
+        ark_ff::batch_inversion::<F>(&mut denominator);
         let numerator = oracles.zeta.pow(&[n]) - &F::one();
 
         vec![

--- a/circuits/plonk/src/polynomials/permutation.rs
+++ b/circuits/plonk/src/polynomials/permutation.rs
@@ -7,8 +7,8 @@ This source file implements permutation constraint polynomial.
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::{ProofEvaluations, RandomOracles};
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk/src/polynomials/poseidon.rs
+++ b/circuits/plonk/src/polynomials/poseidon.rs
@@ -7,8 +7,8 @@ This source file implements Posedon constraint polynomials.
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::{
     poseidon::{sbox, ArithmeticSpongeParams, PlonkSpongeConstants},
     utils::{EvalUtils, PolyUtils},

--- a/circuits/plonk/src/polynomials/poseidon.rs
+++ b/circuits/plonk/src/polynomials/poseidon.rs
@@ -7,8 +7,8 @@ This source file implements Posedon constraint polynomials.
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::{
     poseidon::{sbox, ArithmeticSpongeParams, PlonkSpongeConstants},
     utils::{EvalUtils, PolyUtils},

--- a/circuits/plonk/src/polynomials/varbasemul.rs
+++ b/circuits/plonk/src/polynomials/varbasemul.rs
@@ -7,8 +7,8 @@ This source file implements short Weierstrass curve variable base scalar multipl
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use ark_ff::{FftField, SquareRootField};
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField, Zero};
+use ark_poly::{univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk/src/polynomials/varbasemul.rs
+++ b/circuits/plonk/src/polynomials/varbasemul.rs
@@ -7,8 +7,8 @@ This source file implements short Weierstrass curve variable base scalar multipl
 use crate::constraints::ConstraintSystem;
 use crate::polynomial::WitnessOverDomains;
 use crate::scalars::ProofEvaluations;
-use algebra::{FftField, SquareRootField};
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::{FftField, SquareRootField};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::utils::{EvalUtils, PolyUtils};
 
 impl<F: FftField + SquareRootField> ConstraintSystem<F> {

--- a/circuits/plonk/src/scalars.rs
+++ b/circuits/plonk/src/scalars.rs
@@ -4,8 +4,8 @@ This source file implements Plonk prover polynomial evaluations primitive.
 
 *****************************************************************************************************************/
 
-use algebra::{FftField, Field};
-use ff_fft::DensePolynomial;
+use ark_ff::{FftField, Field};
+use ark_poly::DensePolynomial;
 use oracle::{sponge::ScalarChallenge, utils::PolyUtils};
 
 #[derive(Clone)]

--- a/circuits/plonk/src/scalars.rs
+++ b/circuits/plonk/src/scalars.rs
@@ -5,7 +5,7 @@ This source file implements Plonk prover polynomial evaluations primitive.
 *****************************************************************************************************************/
 
 use ark_ff::{FftField, Field};
-use ark_poly::DensePolynomial;
+use ark_poly::univariate::DensePolynomial;
 use oracle::{sponge::ScalarChallenge, utils::PolyUtils};
 
 #[derive(Clone)]

--- a/circuits/plonk/src/wires.rs
+++ b/circuits/plonk/src/wires.rs
@@ -4,7 +4,7 @@ This source file implements Plonk circuit gate wires primitive.
 
 *****************************************************************************************************************/
 
-use algebra::bytes::{FromBytes, ToBytes};
+use ark_ff::bytes::{FromBytes, ToBytes};
 use std::io::{Read, Result as IoResult, Write};
 
 #[derive(Clone, Copy, Debug)]

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-algebra = { path = "../zexe/algebra", features = ["std", "parallel"] }
-algebra-core = { path = "../zexe/algebra-core", features = ["std"] }
+ark-ec = "0.3.0"
+ark-ff = "0.3.0"
 
 [dev-dependencies]
 rand = { version = "0.7", default-features = false }

--- a/curves/src/pasta/curves/pallas.rs
+++ b/curves/src/pasta/curves/pallas.rs
@@ -1,12 +1,9 @@
 use crate::pasta::*;
-use algebra::{
-    biginteger::BigInteger256,
-    curves::{
-        models::short_weierstrass_jacobian::{GroupAffine, GroupProjective},
-        ModelParameters, SWModelParameters,
-    },
-    field_new, Zero,
+use ark_ec::{
+    models::short_weierstrass_jacobian::{GroupAffine, GroupProjective},
+    ModelParameters, SWModelParameters,
 };
+use ark_ff::{biginteger::BigInteger256, field_new, Zero};
 
 #[derive(Copy, Clone, Default, PartialEq, Eq)]
 pub struct PallasParameters;

--- a/curves/src/pasta/curves/pallas.rs
+++ b/curves/src/pasta/curves/pallas.rs
@@ -18,32 +18,16 @@ pub type Projective = GroupProjective<PallasParameters>;
 
 impl SWModelParameters for PallasParameters {
     /// COEFF_A = 0
-    const COEFF_A: Fp = field_new!(Fp, BigInteger256([0x0, 0x0, 0x0, 0x0]));
+    const COEFF_A: Fp = field_new!(Fp, "0");
 
     /// COEFF_B = 5
-    const COEFF_B: Fp = field_new!(
-        Fp,
-        BigInteger256([
-            0xa1a55e68ffffffed,
-            0x74c2a54b4f4982f3,
-            0xfffffffffffffffd,
-            0x3fffffffffffffff
-        ])
-    );
+    const COEFF_B: Fp = field_new!(Fp, "5");
 
     /// COFACTOR = 1
     const COFACTOR: &'static [u64] = &[0x1];
 
     /// COFACTOR_INV = 1
-    const COFACTOR_INV: Fq = field_new!(
-        Fq,
-        BigInteger256([
-            0x5b2b3e9cfffffffd,
-            0x992c350be3420567,
-            0xffffffffffffffff,
-            0x3fffffffffffffff
-        ])
-    );
+    const COFACTOR_INV: Fq = field_new!(Fq, "1");
 
     /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
     const AFFINE_GENERATOR_COEFFS: (Self::BaseField, Self::BaseField) =
@@ -57,24 +41,11 @@ impl SWModelParameters for PallasParameters {
 
 /// G_GENERATOR_X =
 /// 1
-pub const G_GENERATOR_X: Fp = field_new!(
-    Fp,
-    BigInteger256([
-        0x34786d38fffffffd,
-        0x992c350be41914ad,
-        0xffffffffffffffff,
-        0x3fffffffffffffff
-    ])
-);
+pub const G_GENERATOR_X: Fp = field_new!(Fp, "1");
 
 /// G1_GENERATOR_Y =
 /// 12418654782883325593414442427049395787963493412651469444558597405572177144507
 pub const G_GENERATOR_Y: Fp = field_new!(
     Fp,
-    BigInteger256([
-        0x2f474795455d409d,
-        0xb443b9b74b8255d9,
-        0x270c412f2c9a5d66,
-        0x8e00f71ba43dd6b
-    ])
+    "12418654782883325593414442427049395787963493412651469444558597405572177144507"
 );

--- a/curves/src/pasta/curves/pallas.rs
+++ b/curves/src/pasta/curves/pallas.rs
@@ -3,7 +3,7 @@ use ark_ec::{
     models::short_weierstrass_jacobian::{GroupAffine, GroupProjective},
     ModelParameters, SWModelParameters,
 };
-use ark_ff::{biginteger::BigInteger256, field_new, Zero};
+use ark_ff::{field_new, Zero};
 
 #[derive(Copy, Clone, Default, PartialEq, Eq)]
 pub struct PallasParameters;

--- a/curves/src/pasta/curves/vesta.rs
+++ b/curves/src/pasta/curves/vesta.rs
@@ -1,12 +1,9 @@
 use crate::pasta::*;
-use algebra::{
-    biginteger::BigInteger256,
-    curves::{
-        models::short_weierstrass_jacobian::{GroupAffine, GroupProjective},
-        ModelParameters, SWModelParameters,
-    },
-    field_new, Zero,
+use ark_ec::{
+    models::short_weierstrass_jacobian::{GroupAffine, GroupProjective},
+    ModelParameters, SWModelParameters,
 };
+use ark_ff::{biginteger::BigInteger256, field_new, Zero};
 
 #[derive(Copy, Clone, Default, PartialEq, Eq)]
 pub struct VestaParameters;

--- a/curves/src/pasta/curves/vesta.rs
+++ b/curves/src/pasta/curves/vesta.rs
@@ -18,32 +18,16 @@ pub type Projective = GroupProjective<VestaParameters>;
 
 impl SWModelParameters for VestaParameters {
     /// COEFF_A = 0
-    const COEFF_A: Fq = field_new!(Fq, BigInteger256([0x0, 0x0, 0x0, 0x0]));
+    const COEFF_A: Fq = field_new!(Fq, "0");
 
     /// COEFF_B = 5
-    const COEFF_B: Fq = field_new!(
-        Fq,
-        BigInteger256([
-            0x96bc8c8cffffffed,
-            0x74c2a54b49f7778e,
-            0xfffffffffffffffd,
-            0x3fffffffffffffff
-        ])
-    );
+    const COEFF_B: Fq = field_new!(Fq, "5");
 
     /// COFACTOR = 1
     const COFACTOR: &'static [u64] = &[0x1];
 
     /// COFACTOR_INV = 1
-    const COFACTOR_INV: Fp = field_new!(
-        Fp,
-        BigInteger256([
-            0x34786d38fffffffd,
-            0x992c350be41914ad,
-            0xffffffffffffffff,
-            0x3fffffffffffffff
-        ])
-    );
+    const COFACTOR_INV: Fp = field_new!(Fp, "1");
 
     /// AFFINE_GENERATOR_COEFFS = (G1_GENERATOR_X, G1_GENERATOR_Y)
     const AFFINE_GENERATOR_COEFFS: (Self::BaseField, Self::BaseField) =
@@ -57,24 +41,11 @@ impl SWModelParameters for VestaParameters {
 
 /// G_GENERATOR_X =
 /// 1
-pub const G_GENERATOR_X: Fq = field_new!(
-    Fq,
-    BigInteger256([
-        0x5b2b3e9cfffffffd,
-        0x992c350be3420567,
-        0xffffffffffffffff,
-        0x3fffffffffffffff
-    ])
-);
+pub const G_GENERATOR_X: Fq = field_new!(Fq, "1");
 
 /// G1_GENERATOR_Y =
 /// 11426906929455361843568202299992114520848200991084027513389447476559454104162
 pub const G_GENERATOR_Y: Fq = field_new!(
     Fq,
-    BigInteger256([
-        0x9aae9ab8f909fe12,
-        0x4ef425ddfec978ab,
-        0x80532e1caba65bb9,
-        0x1104486c25ae2958
-    ])
+    "11426906929455361843568202299992114520848200991084027513389447476559454104162"
 );

--- a/curves/src/pasta/curves/vesta.rs
+++ b/curves/src/pasta/curves/vesta.rs
@@ -3,7 +3,7 @@ use ark_ec::{
     models::short_weierstrass_jacobian::{GroupAffine, GroupProjective},
     ModelParameters, SWModelParameters,
 };
-use ark_ff::{biginteger::BigInteger256, field_new, Zero};
+use ark_ff::{field_new, Zero};
 
 #[derive(Copy, Clone, Default, PartialEq, Eq)]
 pub struct VestaParameters;

--- a/curves/src/pasta/fields/fp.rs
+++ b/curves/src/pasta/fields/fp.rs
@@ -1,7 +1,4 @@
-use algebra_core::{
-    biginteger::BigInteger256 as BigInteger,
-    fields::{FftParameters, Fp256, Fp256Parameters},
-};
+use ark_ff::{biginteger::BigInteger256 as BigInteger, FftParameters, Fp256, Fp256Parameters};
 
 pub type Fp = Fp256<FpParameters>;
 
@@ -19,7 +16,7 @@ impl FftParameters for FpParameters {
     ]);
 }
 
-impl algebra_core::fields::FpParameters for FpParameters {
+impl ark_ff::FpParameters for FpParameters {
     // 28948022309329048855892746252171976963363056481941560715954676764349967630337
     const MODULUS: BigInteger = BigInteger([
         0x992d30ed00000001,

--- a/curves/src/pasta/fields/fq.rs
+++ b/curves/src/pasta/fields/fq.rs
@@ -1,6 +1,5 @@
-use algebra_core::{
-    biginteger::BigInteger256 as BigInteger,
-    fields::{FftParameters, Fp256, Fp256Parameters, FpParameters},
+use ark_ff::{
+    biginteger::BigInteger256 as BigInteger, FftParameters, Fp256, Fp256Parameters, FpParameters,
 };
 
 pub struct FqParameters;

--- a/dlog/Cargo.toml
+++ b/dlog/Cargo.toml
@@ -20,3 +20,4 @@ rayon = { version = "1" }
 
 [dev-dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
+ark-poly = { version = "0.3.0", features = [ "parallel" ] }

--- a/dlog/Cargo.toml
+++ b/dlog/Cargo.toml
@@ -4,10 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-algebra = { path = "../zexe/algebra", features = [ "parallel", "asm" ] }
 groupmap = { path = "../groupmap" }
 mina-curves = { path = "../curves" }
-ff-fft = { path = "../zexe/ff-fft", features = [ "parallel" ] }
 commitment_dlog = { path = "commitment" }
 plonk_circuits = { path = "../circuits/plonk" }
 plonk_protocol_dlog = { path = "plonk" }
@@ -19,3 +17,6 @@ colored = "1.9.2"
 rand = "0.7.3"
 sprs = "0.7.1"
 rayon = { version = "1" }
+
+[dev-dependencies]
+ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }

--- a/dlog/commitment/Cargo.toml
+++ b/dlog/commitment/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies]
-algebra = { path = "../../zexe/algebra", features = [ "parallel", "asm" ] }
+ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
+ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 mina-curves = { path = "../../curves" }
 groupmap = { path = "../../groupmap" }
-ff-fft = { path = "../../zexe/ff-fft", features = [ "parallel" ] }
 ocaml = { version = "0.18.1", optional = true }
 oracle = { path = "../../oracle" }
 rand_core = { version = "0.5" }

--- a/dlog/commitment/Cargo.toml
+++ b/dlog/commitment/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
+ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 mina-curves = { path = "../../curves" }
 groupmap = { path = "../../groupmap" }
 ocaml = { version = "0.18.1", optional = true }

--- a/dlog/commitment/src/combine.rs
+++ b/dlog/commitment/src/combine.rs
@@ -1,5 +1,5 @@
-use ark_ec::{curves::models::short_weierstrass_jacobian::GroupAffine as SWJAffine, AffineCurve};
-use ark_ff::{BitIterator, Field, One, PrimeField, ProjectiveCurve, SWModelParameters, Zero};
+use ark_ec::{models::short_weierstrass_jacobian::GroupAffine as SWJAffine, AffineCurve};
+use ark_ff::{BitIteratorBE, Field, One, PrimeField, ProjectiveCurve, SWModelParameters, Zero};
 use itertools::Itertools;
 use rayon::prelude::*;
 
@@ -134,8 +134,8 @@ fn affine_combine_base<P: SWModelParameters>(
     };
     assert!(g1g2.len() == n);
 
-    let bits1 = BitIterator::new(x1.into_repr());
-    let bits2 = BitIterator::new(x2.into_repr());
+    let bits1 = BitIteratorBE::new(x1.into_repr());
+    let bits2 = BitIteratorBE::new(x2.into_repr());
 
     let mut p = vec![SWJAffine::<P>::zero(); n];
 
@@ -195,8 +195,8 @@ fn affine_window_combine_base<P: SWModelParameters>(
     };
     assert!(g1g2.len() == n);
 
-    let windows1 = BitIterator::new(x1.into_repr()).tuples();
-    let windows2 = BitIterator::new(x2.into_repr()).tuples();
+    let windows1 = BitIteratorBE::new(x1.into_repr()).tuples();
+    let windows2 = BitIteratorBE::new(x2.into_repr()).tuples();
 
     let mut p = vec![SWJAffine::<P>::zero(); n];
 
@@ -257,7 +257,7 @@ fn affine_window_combine_one_base<P: SWModelParameters>(
 ) -> Vec<SWJAffine<P>> {
     let n = g1.len();
 
-    let windows2 = BitIterator::new(x2.into_repr()).tuples();
+    let windows2 = BitIteratorBE::new(x2.into_repr()).tuples();
 
     let mut p = vec![SWJAffine::<P>::zero(); n];
 
@@ -389,8 +389,8 @@ fn shamir_sum<G: AffineCurve>(
     g1g2.add_assign_mixed(&g2);
     let g1g2 = g1g2.into_affine();
 
-    let bits1 = BitIterator::new(x1.into_repr());
-    let bits2 = BitIterator::new(x2.into_repr());
+    let bits1 = BitIteratorBE::new(x1.into_repr());
+    let bits2 = BitIteratorBE::new(x2.into_repr());
 
     let mut res = G::Projective::zero();
 
@@ -530,8 +530,8 @@ fn window_shamir<G: AffineCurve>(
     let [_g00_00, g01_00, g10_00, g11_00, g00_01, g01_01, g10_01, g11_01, g00_10, g01_10, g10_10, g11_10, g00_11, g01_11, g10_11, g11_11] =
         shamir_window_table(g1, g2);
 
-    let windows1 = BitIterator::new(x1.into_repr()).tuples();
-    let windows2 = BitIterator::new(x2.into_repr()).tuples();
+    let windows1 = BitIteratorBE::new(x1.into_repr()).tuples();
+    let windows2 = BitIteratorBE::new(x2.into_repr()).tuples();
 
     let mut res = G::Projective::zero();
 

--- a/dlog/commitment/src/combine.rs
+++ b/dlog/commitment/src/combine.rs
@@ -1,7 +1,5 @@
-use algebra::{
-    curves::models::short_weierstrass_jacobian::GroupAffine as SWJAffine, AffineCurve, BitIterator,
-    Field, One, PrimeField, ProjectiveCurve, SWModelParameters, Zero,
-};
+use ark_ec::{curves::models::short_weierstrass_jacobian::GroupAffine as SWJAffine, AffineCurve};
+use ark_ff::{BitIterator, Field, One, PrimeField, ProjectiveCurve, SWModelParameters, Zero};
 use itertools::Itertools;
 use rayon::prelude::*;
 

--- a/dlog/commitment/src/combine.rs
+++ b/dlog/commitment/src/combine.rs
@@ -1,5 +1,8 @@
-use ark_ec::{models::short_weierstrass_jacobian::GroupAffine as SWJAffine, AffineCurve};
-use ark_ff::{BitIteratorBE, Field, One, PrimeField, ProjectiveCurve, SWModelParameters, Zero};
+use ark_ec::{
+    models::short_weierstrass_jacobian::GroupAffine as SWJAffine, AffineCurve, ProjectiveCurve,
+    SWModelParameters,
+};
+use ark_ff::{BitIteratorBE, Field, One, PrimeField, Zero};
 use itertools::Itertools;
 use rayon::prelude::*;
 
@@ -24,7 +27,7 @@ fn add_pairs_in_place<P: SWModelParameters>(p: &mut Vec<SWJAffine<P>>) {
         })
         .collect::<Vec<_>>();
 
-    algebra::fields::batch_inversion::<P::BaseField>(&mut denominators);
+    ark_ff::batch_inversion::<P::BaseField>(&mut denominators);
 
     for (i, d) in (0..len).step_by(2).zip(denominators.iter()) {
         let j = i / 2;
@@ -81,7 +84,7 @@ fn batch_add_assign<P: SWModelParameters>(
         denominators[i] = d;
     }
 
-    algebra::fields::batch_inversion::<P::BaseField>(&mut denominators);
+    ark_ff::batch_inversion::<P::BaseField>(&mut denominators);
 
     for (i, d) in (0..n).zip(denominators.iter()) {
         let p0 = v0[i];
@@ -147,7 +150,7 @@ fn affine_combine_base<P: SWModelParameters>(
             for i in 0..n {
                 denominators[i] = p[i].y.double();
             }
-            algebra::fields::batch_inversion::<P::BaseField>(&mut denominators);
+            ark_ff::batch_inversion::<P::BaseField>(&mut denominators);
 
             // TODO: Use less memory
             for i in 0..n {
@@ -211,7 +214,7 @@ fn affine_window_combine_base<P: SWModelParameters>(
             for i in 0..n {
                 denominators[i] = p[i].y.double();
             }
-            algebra::fields::batch_inversion::<P::BaseField>(&mut denominators);
+            ark_ff::batch_inversion::<P::BaseField>(&mut denominators);
 
             // TODO: Use less memory
             for i in 0..n {
@@ -271,7 +274,7 @@ fn affine_window_combine_one_base<P: SWModelParameters>(
             for i in 0..n {
                 denominators[i] = p[i].y.double();
             }
-            algebra::fields::batch_inversion::<P::BaseField>(&mut denominators);
+            ark_ff::batch_inversion::<P::BaseField>(&mut denominators);
 
             // TODO: Use less memory
             for i in 0..n {

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -12,12 +12,12 @@ The folowing functionality is implemented
 
 use crate::srs::SRS;
 pub use crate::CommitmentField;
-use algebra::{
-    curves::models::short_weierstrass_jacobian::GroupAffine as SWJAffine, AffineCurve, Field,
-    FpParameters, One, PrimeField, ProjectiveCurve, SWModelParameters, SquareRootField,
+use ark_ec::{curves::models::short_weierstrass_jacobian::GroupAffine as SWJAffine, AffineCurve};
+use ark_ff::{
+    Field, FpParameters, One, PrimeField, ProjectiveCurve, SWModelParameters, SquareRootField,
     UniformRand, VariableBaseMSM, Zero,
 };
-use ff_fft::DensePolynomial;
+use ark_poly::DensePolynomial;
 use groupmap::{BWParameters, GroupMap};
 use oracle::{sponge::ScalarChallenge, FqSponge};
 use rand_core::RngCore;

--- a/dlog/commitment/src/commitment.rs
+++ b/dlog/commitment/src/commitment.rs
@@ -12,12 +12,12 @@ The folowing functionality is implemented
 
 use crate::srs::SRS;
 pub use crate::CommitmentField;
-use ark_ec::{curves::models::short_weierstrass_jacobian::GroupAffine as SWJAffine, AffineCurve};
-use ark_ff::{
-    Field, FpParameters, One, PrimeField, ProjectiveCurve, SWModelParameters, SquareRootField,
-    UniformRand, VariableBaseMSM, Zero,
+use ark_ec::{
+    models::short_weierstrass_jacobian::GroupAffine as SWJAffine, msm::VariableBaseMSM,
+    AffineCurve, ProjectiveCurve, SWModelParameters,
 };
-use ark_poly::DensePolynomial;
+use ark_ff::{Field, FpParameters, One, PrimeField, SquareRootField, UniformRand, Zero};
+use ark_poly::{univariate::DensePolynomial, Polynomial, UVPolynomial};
 use groupmap::{BWParameters, GroupMap};
 use oracle::{sponge::ScalarChallenge, FqSponge};
 use rand_core::RngCore;
@@ -151,7 +151,7 @@ where
 
         let chal_inv = {
             let mut cs = chal.clone();
-            algebra::fields::batch_inversion(&mut cs);
+            ark_ff::batch_inversion(&mut cs);
             cs
         };
 

--- a/dlog/commitment/src/qnr_field.rs
+++ b/dlog/commitment/src/qnr_field.rs
@@ -1,4 +1,4 @@
-use algebra::{field_new, BigInteger256, SquareRootField};
+use ark_ff::{field_new, BigInteger256, SquareRootField};
 use mina_curves::pasta;
 
 pub trait QnrField: SquareRootField {

--- a/dlog/commitment/src/qnr_field.rs
+++ b/dlog/commitment/src/qnr_field.rs
@@ -1,32 +1,16 @@
-use ark_ff::{field_new, BigInteger256, SquareRootField};
-use mina_curves::pasta;
+use ark_ff::{field_new, SquareRootField};
+use mina_curves::pasta::{Fp, Fq};
 
 pub trait QnrField: SquareRootField {
     const QNR: Self;
 }
 
-impl QnrField for pasta::Fp {
+impl QnrField for Fp {
     // 5
-    const QNR: Self = field_new!(
-        Self,
-        BigInteger256([
-            0xa1a55e68ffffffed,
-            0x74c2a54b4f4982f3,
-            0xfffffffffffffffd,
-            0x3fffffffffffffff
-        ])
-    );
+    const QNR: Self = field_new!(Fp, "5");
 }
 
-impl QnrField for pasta::Fq {
+impl QnrField for Fq {
     // 5
-    const QNR: Self = field_new!(
-        Self,
-        BigInteger256([
-            0x96bc8c8cffffffed,
-            0x74c2a54b49f7778e,
-            0xfffffffffffffffd,
-            0x3fffffffffffffff
-        ])
-    );
+    const QNR: Self = field_new!(Fq, "5");
 }

--- a/dlog/commitment/src/srs.rs
+++ b/dlog/commitment/src/srs.rs
@@ -46,6 +46,7 @@ where
     G::BaseField: PrimeField,
     G::ScalarField: CommitmentField,
 {
+    // packing in bit-representation
     const N: usize = 31;
     let mut bits = [false; 8 * N];
     for i in 0..N {
@@ -54,8 +55,8 @@ where
         }
     }
 
-    let n = <G::BaseField as PrimeField>::BigInt::from_bits(&bits);
-    let t = G::BaseField::from_repr(n);
+    let n = <G::BaseField as PrimeField>::BigInt::from_bits_be(&bits);
+    let t = G::BaseField::from_repr(n).expect("packing code has a bug");
     let (x, y) = m.to_group(t);
     G::of_coordinates(x, y)
 }

--- a/dlog/commitment/src/srs.rs
+++ b/dlog/commitment/src/srs.rs
@@ -6,7 +6,7 @@ This source file implements the Marlin structured reference string primitive
 
 use crate::commitment::CommitmentCurve;
 pub use crate::{CommitmentField, QnrField};
-use algebra::{BigInteger, FromBytes, PrimeField, ToBytes};
+use ark_ff::{BigInteger, FromBytes, PrimeField, ToBytes};
 use array_init::array_init;
 use blake2::{Blake2b, Digest};
 use groupmap::GroupMap;

--- a/dlog/plonk-5-wires/Cargo.toml
+++ b/dlog/plonk-5-wires/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
+ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 mina-curves = { path = "../../curves" }
 commitment_dlog = { path = "../commitment" }
 plonk_5_wires_circuits = { path = "../../circuits/plonk-5-wires" }

--- a/dlog/plonk-5-wires/Cargo.toml
+++ b/dlog/plonk-5-wires/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies]
-algebra = { path = "../../zexe/algebra", features = [ "parallel", "asm" ] }
+ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
+ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 mina-curves = { path = "../../curves" }
-ff-fft = { path = "../../zexe/ff-fft", features = [ "parallel"] }
 commitment_dlog = { path = "../commitment" }
 plonk_5_wires_circuits = { path = "../../circuits/plonk-5-wires" }
 ocaml = { version = "0.18.1", optional = true }

--- a/dlog/plonk-5-wires/src/index.rs
+++ b/dlog/plonk-5-wires/src/index.rs
@@ -4,15 +4,15 @@ This source file implements Plonk Protocol Index primitive.
 
 *****************************************************************************************************************/
 
-use algebra::AffineCurve;
-use algebra::PrimeField;
+use ark_ec::AffineCurve;
+use ark_ff::PrimeField;
 use array_init::array_init;
 use commitment_dlog::{
     commitment::{CommitmentCurve, PolyComm},
     srs::{SRSSpec, SRSValue},
     CommitmentField,
 };
-use ff_fft::{DensePolynomial, Radix2EvaluationDomain as D};
+use ark_poly::{DensePolynomial, Radix2EvaluationDomain as D};
 use oracle::poseidon::{ArithmeticSpongeParams, PlonkSpongeConstants5W, SpongeConstants};
 use plonk_5_wires_circuits::{
     constraints::{zk_w, ConstraintSystem},

--- a/dlog/plonk-5-wires/src/index.rs
+++ b/dlog/plonk-5-wires/src/index.rs
@@ -6,13 +6,13 @@ This source file implements Plonk Protocol Index primitive.
 
 use ark_ec::AffineCurve;
 use ark_ff::PrimeField;
+use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain as D};
 use array_init::array_init;
 use commitment_dlog::{
     commitment::{CommitmentCurve, PolyComm},
     srs::{SRSSpec, SRSValue},
     CommitmentField,
 };
-use ark_poly::{DensePolynomial, Radix2EvaluationDomain as D};
 use oracle::poseidon::{ArithmeticSpongeParams, PlonkSpongeConstants5W, SpongeConstants};
 use plonk_5_wires_circuits::{
     constraints::{zk_w, ConstraintSystem},

--- a/dlog/plonk-5-wires/src/plonk_sponge.rs
+++ b/dlog/plonk-5-wires/src/plonk_sponge.rs
@@ -1,4 +1,4 @@
-use algebra::{Field, PrimeField};
+use ark_ff::{Field, PrimeField};
 use oracle::poseidon::{
     ArithmeticSponge, ArithmeticSpongeParams, PlonkSpongeConstants5W as SC, Sponge,
 };

--- a/dlog/plonk-5-wires/src/prover.rs
+++ b/dlog/plonk-5-wires/src/prover.rs
@@ -6,12 +6,13 @@ This source file implements prover's zk-proof primitive.
 
 pub use super::{index::Index, range};
 use crate::plonk_sponge::FrSponge;
-use algebra::{AffineCurve, Field, One, UniformRand, Zero};
+use ark_ec::AffineCurve;
+use ark_ff::{Field, One, UniformRand, Zero};
 use array_init::array_init;
 use commitment_dlog::commitment::{
     b_poly_coefficients, CommitmentCurve, CommitmentField, OpeningProof, PolyComm,
 };
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, utils::PolyUtils, FqSponge};
 use plonk_5_wires_circuits::{
     scalars::{ProofEvaluations, RandomOracles},

--- a/dlog/plonk-5-wires/src/prover.rs
+++ b/dlog/plonk-5-wires/src/prover.rs
@@ -8,11 +8,13 @@ pub use super::{index::Index, range};
 use crate::plonk_sponge::FrSponge;
 use ark_ec::AffineCurve;
 use ark_ff::{Field, One, UniformRand, Zero};
+use ark_poly::{
+    univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D, UVPolynomial,
+};
 use array_init::array_init;
 use commitment_dlog::commitment::{
     b_poly_coefficients, CommitmentCurve, CommitmentField, OpeningProof, PolyComm,
 };
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, utils::PolyUtils, FqSponge};
 use plonk_5_wires_circuits::{
     scalars::{ProofEvaluations, RandomOracles},
@@ -214,7 +216,7 @@ where
                 .map(|(w, s)| w[j] + &(s[j] * &oracles.beta) + &oracles.gamma)
                 .fold(Fr::<G>::one(), |x, y| x * y)
         });
-        algebra::fields::batch_inversion::<Fr<G>>(&mut z[1..=n - 3]);
+        ark_ff::batch_inversion::<Fr<G>>(&mut z[1..=n - 3]);
         (0..n - 3).for_each(|j| {
             let x = z[j];
             z[j + 1] *= witness

--- a/dlog/plonk-5-wires/src/range.rs
+++ b/dlog/plonk-5-wires/src/range.rs
@@ -1,4 +1,4 @@
-use algebra::Field;
+use ark_ff::Field;
 use std::ops::Range;
 
 pub const PSDN: Range<usize> = 0..5;

--- a/dlog/plonk-5-wires/src/verifier.rs
+++ b/dlog/plonk-5-wires/src/verifier.rs
@@ -7,11 +7,12 @@ This source file implements zk-proof batch verifier functionality.
 pub use super::index::VerifierIndex as Index;
 pub use super::prover::{range, ProverProof};
 use crate::plonk_sponge::FrSponge;
-use algebra::{AffineCurve, Field, One, Zero};
+use ark_ec::AffineCurve;
+use ark_ff::{Field, One, Zero};
 use commitment_dlog::commitment::{
     b_poly, b_poly_coefficients, combined_inner_product, CommitmentCurve, CommitmentField, PolyComm,
 };
-use ff_fft::EvaluationDomain;
+use ark_poly::EvaluationDomain;
 use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, FqSponge};
 use plonk_5_wires_circuits::{
     constraints::ConstraintSystem, scalars::RandomOracles, wires::COLUMNS,

--- a/dlog/plonk-5-wires/src/verifier.rs
+++ b/dlog/plonk-5-wires/src/verifier.rs
@@ -9,10 +9,10 @@ pub use super::prover::{range, ProverProof};
 use crate::plonk_sponge::FrSponge;
 use ark_ec::AffineCurve;
 use ark_ff::{Field, One, Zero};
+use ark_poly::EvaluationDomain;
 use commitment_dlog::commitment::{
     b_poly, b_poly_coefficients, combined_inner_product, CommitmentCurve, CommitmentField, PolyComm,
 };
-use ark_poly::EvaluationDomain;
 use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, FqSponge};
 use plonk_5_wires_circuits::{
     constraints::ConstraintSystem, scalars::RandomOracles, wires::COLUMNS,
@@ -144,7 +144,7 @@ where
         (0..self.public.len())
             .zip(w.iter())
             .for_each(|(_, w)| lagrange.push(zetaw - w));
-        algebra::fields::batch_inversion::<Fr<G>>(&mut lagrange);
+        ark_ff::batch_inversion::<Fr<G>>(&mut lagrange);
 
         // evaluate public input polynomials
         // NOTE: this works only in the case when the poly segment size is not smaller than that of the domain

--- a/dlog/plonk/Cargo.toml
+++ b/dlog/plonk/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
+ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 mina-curves = { path = "../../curves" }
 commitment_dlog = { path = "../commitment" }
 plonk_circuits = { path = "../../circuits/plonk" }

--- a/dlog/plonk/Cargo.toml
+++ b/dlog/plonk/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies]
-algebra = { path = "../../zexe/algebra", features = [ "parallel", "asm" ] }
+ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
+ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 mina-curves = { path = "../../curves" }
-ff-fft = { path = "../../zexe/ff-fft", features = [ "parallel"] }
 commitment_dlog = { path = "../commitment" }
 plonk_circuits = { path = "../../circuits/plonk" }
 ocaml = { version = "0.18.1", optional = true }

--- a/dlog/plonk/src/index.rs
+++ b/dlog/plonk/src/index.rs
@@ -6,13 +6,13 @@ This source file implements Plonk Protocol Index primitive.
 
 use ark_ec::AffineCurve;
 use ark_ff::PrimeField;
+use ark_poly::{univariate::DensePolynomial, Radix2EvaluationDomain as D};
 use array_init::array_init;
 use commitment_dlog::{
     commitment::{CommitmentCurve, PolyComm},
     srs::{SRSSpec, SRSValue},
     CommitmentField,
 };
-use ark_poly::{DensePolynomial, Radix2EvaluationDomain as D};
 use oracle::poseidon::{ArithmeticSpongeParams, PlonkSpongeConstants, SpongeConstants};
 use plonk_circuits::constraints::{zk_w, ConstraintSystem};
 

--- a/dlog/plonk/src/index.rs
+++ b/dlog/plonk/src/index.rs
@@ -4,15 +4,15 @@ This source file implements Plonk Protocol Index primitive.
 
 *****************************************************************************************************************/
 
-use algebra::AffineCurve;
-use algebra::PrimeField;
+use ark_ec::AffineCurve;
+use ark_ff::PrimeField;
 use array_init::array_init;
 use commitment_dlog::{
     commitment::{CommitmentCurve, PolyComm},
     srs::{SRSSpec, SRSValue},
     CommitmentField,
 };
-use ff_fft::{DensePolynomial, Radix2EvaluationDomain as D};
+use ark_poly::{DensePolynomial, Radix2EvaluationDomain as D};
 use oracle::poseidon::{ArithmeticSpongeParams, PlonkSpongeConstants, SpongeConstants};
 use plonk_circuits::constraints::{zk_w, ConstraintSystem};
 

--- a/dlog/plonk/src/plonk_sponge.rs
+++ b/dlog/plonk/src/plonk_sponge.rs
@@ -1,4 +1,4 @@
-use algebra::{Field, PrimeField};
+use ark_ff::{Field, PrimeField};
 use oracle::poseidon::{
     ArithmeticSponge, ArithmeticSpongeParams, PlonkSpongeConstants as SC, Sponge,
 };

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -6,12 +6,15 @@ This source file implements prover's zk-proof primitive.
 
 pub use super::{index::Index, range};
 use crate::plonk_sponge::FrSponge;
-use ark_ec::AFfineCurve;
+use ark_ec::AffineCurve;
 use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
+use ark_poly::{
+    univariate::{DenseOrSparsePolynomial, DensePolynomial},
+    Evaluations, Radix2EvaluationDomain as D, UVPolynomial,
+};
 use commitment_dlog::commitment::{
     b_poly_coefficients, CommitmentCurve, CommitmentField, OpeningProof, PolyComm,
 };
-use ark_poly::{DenseOrSparsePolynomial, DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, utils::PolyUtils, FqSponge};
 use plonk_circuits::{
     constraints::ConstraintSystem,
@@ -192,7 +195,7 @@ where
                 * &(witness[j + n] + &(index.cs.sigmal1[1][j] * &oracles.beta) + &oracles.gamma)
                 * &(witness[j + 2 * n] + &(index.cs.sigmal1[2][j] * &oracles.beta) + &oracles.gamma)
         });
-        algebra::fields::batch_inversion::<Fr<G>>(&mut z[1..=n - 3]);
+        ark_ff::batch_inversion::<Fr<G>>(&mut z[1..=n - 3]);
         (0..n - 3).for_each(|j| {
             let x = z[j];
             z[j + 1] *= &(x

--- a/dlog/plonk/src/prover.rs
+++ b/dlog/plonk/src/prover.rs
@@ -6,11 +6,12 @@ This source file implements prover's zk-proof primitive.
 
 pub use super::{index::Index, range};
 use crate::plonk_sponge::FrSponge;
-use algebra::{AffineCurve, Field, One, PrimeField, UniformRand, Zero};
+use ark_ec::AFfineCurve;
+use ark_ff::{Field, One, PrimeField, UniformRand, Zero};
 use commitment_dlog::commitment::{
     b_poly_coefficients, CommitmentCurve, CommitmentField, OpeningProof, PolyComm,
 };
-use ff_fft::{DenseOrSparsePolynomial, DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{DenseOrSparsePolynomial, DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, utils::PolyUtils, FqSponge};
 use plonk_circuits::{
     constraints::ConstraintSystem,

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -9,10 +9,10 @@ pub use super::prover::{range, ProverProof};
 use crate::plonk_sponge::FrSponge;
 use ark_ec::AffineCurve;
 use ark_ff::{Field, One, Zero};
+use ark_poly::EvaluationDomain;
 use commitment_dlog::commitment::{
     b_poly, b_poly_coefficients, combined_inner_product, CommitmentCurve, CommitmentField, PolyComm,
 };
-use ark_poly::EvaluationDomain;
 use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, FqSponge};
 use plonk_circuits::{constraints::ConstraintSystem, scalars::RandomOracles};
 use rand::thread_rng;
@@ -154,7 +154,7 @@ where
         (0..self.public.len())
             .zip(w.iter())
             .for_each(|(_, w)| lagrange.push(zetaw - w));
-        algebra::fields::batch_inversion::<Fr<G>>(&mut lagrange);
+        ark_ff::batch_inversion::<Fr<G>>(&mut lagrange);
 
         // evaluate public input polynomials
         // NOTE: this works only in the case when the poly segment size is not smaller than that of the domain

--- a/dlog/plonk/src/verifier.rs
+++ b/dlog/plonk/src/verifier.rs
@@ -7,11 +7,12 @@ This source file implements zk-proof batch verifier functionality.
 pub use super::index::VerifierIndex as Index;
 pub use super::prover::{range, ProverProof};
 use crate::plonk_sponge::FrSponge;
-use algebra::{AffineCurve, Field, One, Zero};
+use ark_ec::AffineCurve;
+use ark_ff::{Field, One, Zero};
 use commitment_dlog::commitment::{
     b_poly, b_poly_coefficients, combined_inner_product, CommitmentCurve, CommitmentField, PolyComm,
 };
-use ff_fft::EvaluationDomain;
+use ark_poly::EvaluationDomain;
 use oracle::{rndoracle::ProofError, sponge::ScalarChallenge, FqSponge};
 use plonk_circuits::{constraints::ConstraintSystem, scalars::RandomOracles};
 use rand::thread_rng;

--- a/dlog/tests/batch.rs
+++ b/dlog/tests/batch.rs
@@ -5,7 +5,7 @@ verification of a batch of batched opening proofs of polynomial commitments
 
 *****************************************************************************************************************/
 
-use algebra::UniformRand;
+use ark_ff::UniformRand;
 use commitment_dlog::{commitment::CommitmentCurve, srs::SRS};
 use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
@@ -18,7 +18,7 @@ use oracle::sponge::DefaultFqSponge;
 use oracle::FqSponge;
 
 use colored::Colorize;
-use ff_fft::DensePolynomial;
+use ark_poly::DensePolynomial;
 use groupmap::GroupMap;
 use rand::Rng;
 use std::time::{Duration, Instant};

--- a/dlog/tests/batch.rs
+++ b/dlog/tests/batch.rs
@@ -17,8 +17,8 @@ use oracle::poseidon::PlonkSpongeConstants as SC;
 use oracle::sponge::DefaultFqSponge;
 use oracle::FqSponge;
 
+use ark_poly::univariate::DensePolynomial;
 use colored::Colorize;
-use ark_poly::DensePolynomial;
 use groupmap::GroupMap;
 use rand::Rng;
 use std::time::{Duration, Instant};

--- a/dlog/tests/batch_5_wires.rs
+++ b/dlog/tests/batch_5_wires.rs
@@ -17,8 +17,8 @@ use oracle::poseidon::PlonkSpongeConstants5W as SC;
 use oracle::sponge::DefaultFqSponge;
 use oracle::FqSponge;
 
+use ark_poly::univariate::DensePolynomial;
 use colored::Colorize;
-use ark_poly::DensePolynomial;
 use groupmap::GroupMap;
 use rand::Rng;
 use std::time::{Duration, Instant};

--- a/dlog/tests/batch_5_wires.rs
+++ b/dlog/tests/batch_5_wires.rs
@@ -5,7 +5,7 @@ verification of a batch of batched opening proofs of polynomial commitments
 
 *****************************************************************************************************************/
 
-use algebra::UniformRand;
+use ark_ff::UniformRand;
 use commitment_dlog::{commitment::CommitmentCurve, srs::SRS};
 use mina_curves::pasta::{
     vesta::{Affine, VestaParameters},
@@ -18,7 +18,7 @@ use oracle::sponge::DefaultFqSponge;
 use oracle::FqSponge;
 
 use colored::Colorize;
-use ff_fft::DensePolynomial;
+use ark_poly::DensePolynomial;
 use groupmap::GroupMap;
 use rand::Rng;
 use std::time::{Duration, Instant};

--- a/dlog/tests/turbo_plonk.rs
+++ b/dlog/tests/turbo_plonk.rs
@@ -21,13 +21,13 @@ This source file tests constraints for the following computatios:
 
 **********************************************************************************************************/
 
-use algebra::{Field, One, UniformRand, Zero};
+use ark_ff::{Field, One, UniformRand, Zero};
 use colored::Colorize;
 use commitment_dlog::{
     commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
     srs::{SRSSpec, SRS},
 };
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     pallas::Affine as Other,

--- a/dlog/tests/turbo_plonk.rs
+++ b/dlog/tests/turbo_plonk.rs
@@ -22,12 +22,14 @@ This source file tests constraints for the following computatios:
 **********************************************************************************************************/
 
 use ark_ff::{Field, One, UniformRand, Zero};
+use ark_poly::{
+    univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D, UVPolynomial,
+};
 use colored::Colorize;
 use commitment_dlog::{
     commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
     srs::{SRSSpec, SRS},
 };
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     pallas::Affine as Other,

--- a/dlog/tests/turbo_plonk_5_wires.rs
+++ b/dlog/tests/turbo_plonk_5_wires.rs
@@ -32,12 +32,14 @@ This source file tests constraints for the following computations:
 **********************************************************************************************************/
 
 use ark_ff::{BigInteger, Field, One, PrimeField, SquareRootField, UniformRand, Zero};
+use ark_poly::{
+    univariate::DensePolynomial, Evaluations, Radix2EvaluationDomain as D, UVPolynomial,
+};
 use colored::Colorize;
 use commitment_dlog::{
     commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
     srs::{endos, SRSSpec, SRS},
 };
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     pallas::Affine as Other,

--- a/dlog/tests/turbo_plonk_5_wires.rs
+++ b/dlog/tests/turbo_plonk_5_wires.rs
@@ -31,13 +31,13 @@ This source file tests constraints for the following computations:
 
 **********************************************************************************************************/
 
-use algebra::{BigInteger, Field, One, PrimeField, SquareRootField, UniformRand, Zero};
+use ark_ff::{BigInteger, Field, One, PrimeField, SquareRootField, UniformRand, Zero};
 use colored::Colorize;
 use commitment_dlog::{
     commitment::{b_poly_coefficients, ceil_log2, CommitmentCurve},
     srs::{endos, SRSSpec, SRS},
 };
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use groupmap::GroupMap;
 use mina_curves::pasta::{
     pallas::Affine as Other,

--- a/groupmap/Cargo.toml
+++ b/groupmap/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-algebra = { path = "../zexe/algebra", features = [ "parallel" ] }
+ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
+ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 rand = { version = "0.7" }
 
 [dev-dependencies]

--- a/groupmap/src/lib.rs
+++ b/groupmap/src/lib.rs
@@ -1,8 +1,5 @@
-use algebra::{
-    curves::models::SWModelParameters,
-    fields::{Field, SquareRootField},
-    One, Zero,
-};
+use ark_ec::models::SWModelParameters;
+use ark_ff::{Field, One, SquareRootField, Zero};
 
 pub trait GroupMap<F> {
     fn setup() -> Self;
@@ -157,7 +154,7 @@ impl<G: SWModelParameters> GroupMap<G::BaseField> for BWParameters<G> {
             .collect();
 
         let mut alphas: Vec<G::BaseField> = t2_alpha_invs.iter().map(|(_, a)| a.clone()).collect();
-        algebra::fields::batch_inversion::<G::BaseField>(&mut alphas);
+        ark_ff::batch_inversion::<G::BaseField>(&mut alphas);
 
         let potential_xs = t2_alpha_invs
             .iter()

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 [dependencies]
 ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
 ark-ec = { version = "0.3.0", features = [ "parallel" ] }
+ark-poly = { version = "0.3.0", features = [ "parallel" ] }
 mina-curves = { path = "../curves" }
 ocaml = { version = "0.18.1", optional = true }
 rand = "0.7.3"

--- a/oracle/Cargo.toml
+++ b/oracle/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 path = "src/lib.rs"
 
 [dependencies]
-algebra = { path = "../zexe/algebra", features = [ "parallel", "asm" ] }
+ark-ff = { version = "0.3.0", features = [ "parallel", "asm" ] }
+ark-ec = { version = "0.3.0", features = [ "parallel" ] }
 mina-curves = { path = "../curves" }
-ff-fft = { path = "../zexe/ff-fft", features = [ "parallel"] }
 ocaml = { version = "0.18.1", optional = true }
 rand = "0.7.3"
 rayon = { version = "1" }

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -4,7 +4,7 @@ pub mod rndoracle;
 pub mod sponge;
 pub mod utils;
 
-use algebra::Field;
+use ark_ff::Field;
 
 pub trait FqSponge<Fq: Field, G, Fr> {
     fn new(p: poseidon::ArithmeticSpongeParams<Fq>) -> Self;

--- a/oracle/src/poseidon.rs
+++ b/oracle/src/poseidon.rs
@@ -4,7 +4,7 @@ This file implements Poseidon Hash Function primitive
 
 *****************************************************************************************************************/
 
-use algebra::Field;
+use ark_ff::Field;
 
 pub trait SpongeConstants {
     const ROUNDS_FULL: usize;

--- a/oracle/src/sponge.rs
+++ b/oracle/src/sponge.rs
@@ -1,8 +1,6 @@
 use crate::poseidon::{ArithmeticSponge, ArithmeticSpongeParams, Sponge, SpongeConstants};
-use algebra::{
-    curves::{short_weierstrass_jacobian::GroupAffine, SWModelParameters},
-    BigInteger, Field, FpParameters, One, PrimeField, Zero,
-};
+use ark_ec::{short_weierstrass_jacobian::GroupAffine, SWModelParameters};
+use ark_ff::{BigInteger, Field, FpParameters, One, PrimeField, Zero};
 
 pub use crate::FqSponge;
 

--- a/oracle/src/utils.rs
+++ b/oracle/src/utils.rs
@@ -1,5 +1,7 @@
 use ark_ff::FftField;
-use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_poly::{
+    univariate::DensePolynomial, Evaluations, Polynomial, Radix2EvaluationDomain as D, UVPolynomial,
+};
 use rayon::prelude::*;
 
 pub trait PolyUtils<F: FftField> {
@@ -93,7 +95,7 @@ impl<F: FftField> PolyUtils<F> for DensePolynomial<F> {
                         i + size
                     }],
                 )
-                .evaluate(elm)
+                .evaluate(&elm)
             })
             .collect()
     }

--- a/oracle/src/utils.rs
+++ b/oracle/src/utils.rs
@@ -1,5 +1,5 @@
-use algebra::FftField;
-use ff_fft::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
+use ark_ff::FftField;
+use ark_poly::{DensePolynomial, Evaluations, Radix2EvaluationDomain as D};
 use rayon::prelude::*;
 
 pub trait PolyUtils<F: FftField> {

--- a/oracle/tests/poseidon_tests.rs
+++ b/oracle/tests/poseidon_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use algebra::{fields::PrimeField, BigInteger256, UniformRand};
+    use ark_ff::{BigInteger256, PrimeField, UniformRand};
     use mina_curves::pasta::Fp;
     use oracle::poseidon::Sponge; // needed for ::new() sponge
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.45.2"
+channel = "1.52.1"


### PR DESCRIPTION
step 4 needs to land first before this one (https://github.com/o1-labs/marlin/pull/113)

This PR makes the final move from zexe to arkworks. There's a lot of name import changes, and fixes to make things work. What is important is that the fixes don't fix things incorrectly.