### PR TITLE
Simplified sponge interface

### DIFF
--- a/dlog/plonk-5-wires/src/plonk_sponge.rs
+++ b/dlog/plonk-5-wires/src/plonk_sponge.rs
@@ -15,15 +15,14 @@ pub trait FrSponge<Fr: Field> {
 impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr, SC> {
     fn new(params: ArithmeticSpongeParams<Fr>) -> DefaultFrSponge<Fr, SC> {
         DefaultFrSponge {
-            params,
-            sponge: ArithmeticSponge::new(),
+            sponge: ArithmeticSponge::new(params),
             last_squeezed: vec![],
         }
     }
 
     fn absorb(&mut self, x: &Fr) {
         self.last_squeezed = vec![];
-        self.sponge.absorb(&self.params, &[*x]);
+        self.sponge.absorb(&[*x]);
     }
 
     fn challenge(&mut self) -> ScalarChallenge<Fr> {
@@ -32,7 +31,7 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr, SC> {
 
     fn absorb_evaluations(&mut self, p: &[Fr], e: &ProofEvaluations<Vec<Fr>>) {
         self.last_squeezed = vec![];
-        self.sponge.absorb(&self.params, p);
+        self.sponge.absorb(p);
 
         let points = [
             &e.w[0], &e.w[1], &e.w[2], &e.w[3], &e.w[4], &e.z, &e.t, &e.f, &e.s[0], &e.s[1],
@@ -40,7 +39,7 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr, SC> {
         ];
 
         for p in &points {
-            self.sponge.absorb(&self.params, p);
+            self.sponge.absorb(p);
         }
     }
 }

--- a/dlog/plonk/src/plonk_sponge.rs
+++ b/dlog/plonk/src/plonk_sponge.rs
@@ -15,15 +15,14 @@ pub trait FrSponge<Fr: Field> {
 impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr, SC> {
     fn new(params: ArithmeticSpongeParams<Fr>) -> DefaultFrSponge<Fr, SC> {
         DefaultFrSponge {
-            params,
-            sponge: ArithmeticSponge::new(),
+            sponge: ArithmeticSponge::new(params),
             last_squeezed: vec![],
         }
     }
 
     fn absorb(&mut self, x: &Fr) {
         self.last_squeezed = vec![];
-        self.sponge.absorb(&self.params, &[*x]);
+        self.sponge.absorb(&[*x]);
     }
 
     fn challenge(&mut self) -> ScalarChallenge<Fr> {
@@ -32,12 +31,12 @@ impl<Fr: PrimeField> FrSponge<Fr> for DefaultFrSponge<Fr, SC> {
 
     fn absorb_evaluations(&mut self, p: &[Fr], e: &ProofEvaluations<Vec<Fr>>) {
         self.last_squeezed = vec![];
-        self.sponge.absorb(&self.params, p);
+        self.sponge.absorb(p);
 
         let points = [&e.l, &e.r, &e.o, &e.z, &e.f, &e.sigma1, &e.sigma2, &e.t];
 
         for p in &points {
-            self.sponge.absorb(&self.params, p);
+            self.sponge.absorb(p);
         }
     }
 }

--- a/dlog/tests/turbo_plonk.rs
+++ b/dlog/tests/turbo_plonk.rs
@@ -528,8 +528,7 @@ where
 {
     let rng = &mut OsRng;
 
-    let params: ArithmeticSpongeParams<Fp> = oracle::pasta::fp::params();
-    let mut sponge = ArithmeticSponge::<Fp, SC>::new();
+    let mut sponge = ArithmeticSponge::<Fp, SC>::new(oracle::pasta::fp::params());
 
     let z = Fp::zero();
     let mut batch = Vec::new();
@@ -629,7 +628,7 @@ where
 
         // HALF_ROUNDS_FULL full rounds constraint gates
         for j in 0..SC::ROUNDS_FULL {
-            sponge.full_round(j + 1, &params);
+            sponge.full_round(j + 1);
             l.push(sponge.state[0]);
             r.push(sponge.state[1]);
             o.push(sponge.state[2]);
@@ -823,8 +822,7 @@ where
 
     let s = (y2 - &y1) / &(x2 - &x1);
 
-    let mut sponge = ArithmeticSponge::<Fp, SC>::new();
-    let params: ArithmeticSpongeParams<Fp> = oracle::pasta::fp::params();
+    let mut sponge = ArithmeticSponge::<Fp, SC>::new(oracle::pasta::fp::params());
     sponge.state = vec![x1, x2, x3];
     let z = Fp::zero();
 
@@ -882,7 +880,7 @@ where
 
     // ROUNDS_FULL full rounds constraint gates
     for j in 0..SC::ROUNDS_FULL {
-        sponge.full_round(j + 1, &params);
+        sponge.full_round(j + 1);
         l.push(sponge.state[0]);
         r.push(sponge.state[1]);
         o.push(sponge.state[2]);

--- a/dlog/tests/turbo_plonk_5_wires.rs
+++ b/dlog/tests/turbo_plonk_5_wires.rs
@@ -839,7 +839,6 @@ fn positive(index: &Index<Affine>) {
     let rng = &mut OsRng;
     let mut batch = Vec::new();
     let group_map = <Affine as CommitmentCurve>::Map::setup();
-    let params = oracle::pasta::fp5::params();
     let lgr_comms: Vec<_> = (0..PUBLIC)
         .map(|i| {
             let mut v = vec![Fp::zero(); i + 1];
@@ -1016,7 +1015,7 @@ fn positive(index: &Index<Affine>) {
 
         //  witness for Poseidon permutation custom constraints
 
-        let mut sponge = ArithmeticSponge::<Fp, PlonkSpongeConstants5W>::new();
+        let mut sponge = ArithmeticSponge::<Fp, PlonkSpongeConstants5W>::new(oracle::pasta::fp5::params());
         sponge.state = vec![w(), w(), w(), w(), w()];
         witness
             .iter_mut()
@@ -1026,7 +1025,7 @@ fn positive(index: &Index<Affine>) {
         // ROUNDS_FULL full rounds
 
         for j in 0..PlonkSpongeConstants5W::ROUNDS_FULL {
-            sponge.full_round(j, &params);
+            sponge.full_round(j);
             witness
                 .iter_mut()
                 .zip(sponge.state.iter())

--- a/oracle/src/sponge.rs
+++ b/oracle/src/sponge.rs
@@ -62,13 +62,11 @@ impl<F: PrimeField> ScalarChallenge<F> {
 
 #[derive(Clone)]
 pub struct DefaultFqSponge<P: SWModelParameters, SC: SpongeConstants> {
-    pub params: ArithmeticSpongeParams<P::BaseField>,
     pub sponge: ArithmeticSponge<P::BaseField, SC>,
     pub last_squeezed: Vec<u64>,
 }
 
 pub struct DefaultFrSponge<Fr: Field, SC: SpongeConstants> {
-    pub params: ArithmeticSpongeParams<Fr>,
     pub sponge: ArithmeticSponge<Fr, SC>,
     pub last_squeezed: Vec<u64>,
 }
@@ -90,7 +88,7 @@ impl<Fr: PrimeField, SC: SpongeConstants> DefaultFrSponge<Fr, SC> {
             self.last_squeezed = remaining.to_vec();
             Fr::from_repr(pack::<Fr::BigInt>(&limbs))
         } else {
-            let x = self.sponge.squeeze(&self.params).into_repr();
+            let x = self.sponge.squeeze().into_repr();
             self.last_squeezed
                 .extend(&x.as_ref()[0..HIGH_ENTROPY_LIMBS]);
             self.squeeze(num_limbs)
@@ -110,7 +108,7 @@ where
             self.last_squeezed = remaining.to_vec();
             limbs.to_vec()
         } else {
-            let x = self.sponge.squeeze(&self.params).into_repr();
+            let x = self.sponge.squeeze().into_repr();
             self.last_squeezed
                 .extend(&x.as_ref()[0..HIGH_ENTROPY_LIMBS]);
             self.squeeze_limbs(num_limbs)
@@ -119,7 +117,7 @@ where
 
     pub fn squeeze_field(&mut self) -> P::BaseField {
         self.last_squeezed = vec![];
-        self.sponge.squeeze(&self.params)
+        self.sponge.squeeze()
     }
 
     pub fn squeeze(&mut self, num_limbs: usize) -> P::ScalarField {
@@ -135,8 +133,7 @@ where
 {
     fn new(params: ArithmeticSpongeParams<P::BaseField>) -> DefaultFqSponge<P, SC> {
         DefaultFqSponge {
-            params,
-            sponge: ArithmeticSponge::new(),
+            sponge: ArithmeticSponge::new(params),
             last_squeezed: vec![],
         }
     }
@@ -147,8 +144,8 @@ where
             if g.infinity {
                 panic!("sponge got zero curve point");
             } else {
-                self.sponge.absorb(&self.params, &[g.x]);
-                self.sponge.absorb(&self.params, &[g.y]);
+                self.sponge.absorb(&[g.x]);
+                self.sponge.absorb(&[g.y]);
             }
         }
     }
@@ -172,7 +169,6 @@ where
                 < <P::BaseField as PrimeField>::Params::MODULUS.into()
             {
                 self.sponge.absorb(
-                    &self.params,
                     &[P::BaseField::from_repr(
                         <P::BaseField as PrimeField>::BigInt::from_bits(&bits),
                     )],
@@ -188,8 +184,8 @@ where
                     P::BaseField::zero()
                 };
 
-                self.sponge.absorb(&self.params, &[low_bits]);
-                self.sponge.absorb(&self.params, &[high_bit]);
+                self.sponge.absorb(&[low_bits]);
+                self.sponge.absorb(&[high_bit]);
             }
         });
     }

--- a/oracle/tests/poseidon_tests.rs
+++ b/oracle/tests/poseidon_tests.rs
@@ -27,9 +27,9 @@ mod tests {
     fn poseidon() {
         macro_rules! assert_poseidon_eq {
             ($input:expr, $target:expr) => {
-                let mut s = Poseidon::<Fp, PlonkSpongeConstants>::new();
-                s.absorb(&Parameters::params(), $input);
-                let output = s.squeeze(&Parameters::params());
+                let mut s = Poseidon::<Fp, PlonkSpongeConstants>::new(Parameters::params());
+                s.absorb($input);
+                let output = s.squeeze();
                 assert_eq!(
                     output,
                     $target,
@@ -174,9 +174,9 @@ mod tests {
     fn poseidon_5_wires() {
         macro_rules! assert_poseidon_5_wires_eq {
             ($input:expr, $target:expr) => {
-                let mut s = Poseidon::<Fp, PlonkSpongeConstants5W>::new();
-                s.absorb(&Parameters5W::params(), $input);
-                let output = s.squeeze(&Parameters5W::params());
+                let mut s = Poseidon::<Fp, PlonkSpongeConstants5W>::new(Parameters5W::params());
+                s.absorb($input);
+                let output = s.squeeze();
                 assert_eq!(
                     output,
                     $target,
@@ -369,9 +369,9 @@ mod tests {
     fn poseidon_3() {
         macro_rules! assert_poseidon_3_eq {
             ($input:expr, $target:expr) => {
-                let mut s = Poseidon::<Fp, PlonkSpongeConstants3>::new();
-                s.absorb(&Parameters3::params(), $input);
-                let output = s.squeeze(&Parameters3::params());
+                let mut s = Poseidon::<Fp, PlonkSpongeConstants3>::new(Parameters3::params());
+                s.absorb($input);
+                let output = s.squeeze();
                 assert_eq!(
                     output,
                     $target,


### PR DESCRIPTION
This simplifies the sponge interface so we don't need to repeatedly pass the `ArithmeticSpongeParams` everywhere.

See #116 