### PR TITLE
Bump zexe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
     run-tests:
         docker:
-            - image: rust:1.44.1-buster
+            - image: rust:1.52.1-buster
         steps:
             - checkout
             - run:


### PR DESCRIPTION
The zexe submodule somehow got out of sync. This PR updates it to the latest master, which fixes a compile error.